### PR TITLE
Fix ovs connection refused error

### DIFF
--- a/inventory/sample/armada-manifest.yaml
+++ b/inventory/sample/armada-manifest.yaml
@@ -1306,6 +1306,9 @@ data:
     pod:
       replicas:
         server: 1
+    conf:
+      openvswitch_db_server:
+        ptcp_port: 6640
     volume:
       class_name: rbd
     monitoring:


### PR DESCRIPTION
This PR solves #4 by adding the port value of the ovs-db from openvswitch chart.