### PR TITLE
bugfix: kubectl command not found

### DIFF
--- a/vars/global_taco.yml
+++ b/vars/global_taco.yml
@@ -1,5 +1,5 @@
 # Host
-bin_dir: /usr/local/bin
+bin_dir: /usr/bin
 nat_enabled: false
 tc_enabled: false
 


### PR DESCRIPTION
Root user can not find kubectl, helm, kubelet and so on.
Because the binary files are located in /usr/local/bin.
Change the binary install path to /usr/bin like /usr/bin/docker.