### PR TITLE
bugfix: fix wrong url in VERSIONS file

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ kubespray https://github.com/kubernetes-sigs/kubespray.git v2.10.4
 charts/openstack-helm https://github.com/openinfradev/openstack-helm.git taco-v19.03
 charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git taco-v19.03
 ceph-ansible https://github.com/openinfradev/ceph-ansible.git stable-3.2
-charts/helm https://github.com/helm/charts.git taco-v19.03
+charts/helm https://github.com/openinfradev/helm-charts taco-v19.03


### PR DESCRIPTION
VERSIONS file 안에 stable helm charts repo의 URL이 잘못 들어가있어 수정함.