### PR TITLE
add clouds conf to gate directory

### DIFF
--- a/gate/clouds.yaml
+++ b/gate/clouds.yaml
@@ -1,0 +1,10 @@
+clouds:
+  taco-prod:
+    auth:
+      auth_url: http://keystone.openstack.svc.cluster.local:80/v3
+      project_name: CHANGEME
+      username: CHANGEME
+      password: CHANGEME
+      user_domain_name: default
+      project_domain_name: default
+    region_name: RegionOne


### PR DESCRIPTION
CI 환경으로 사용할 Openstack Cloud의 설정 정보를 담고 있는 clouds.yaml 파일을 gate 디렉토리에 추가하여 openstack 호출시 참조하도록 함.

(여러 안 중의 하나이므로 @jacobbaek 님 의견 필요함)