### PR TITLE
modify OSH chart tag in VERSIONS file

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,6 +1,6 @@
 kubespray https://github.com/openinfradev/kubespray.git v2.13.1
-#charts/openstack-helm https://github.com/openinfradev/openstack-helm.git taco-v20.07-v2
-#charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git taco-v20.07-v2
+charts/openstack-helm https://github.com/openinfradev/openstack-helm.git taco-v20.05
+charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git taco-v20.05
 ceph-ansible https://github.com/openinfradev/ceph-ansible.git stable-4.0
 #charts/helm https://github.com/openinfradev/helm-charts.git taco-v20.07-v2
 #charts/taco-helm https://github.com/openinfradev/taco-helm.git taco-v20.07-v2


### PR DESCRIPTION
openstack-helm 및 openstack-helm-infra repo는 v20.05 가 가장 최신 태그이므로 이에 맞게 수정하였습니다.
어차피 online gating에서는 (application) manifest 파일에만 맞게 넣어주면 되지만, 향후 offline gating 시에 사용될 수 있으므로 지금 싱크해놓는 게 좋을 듯 해서요.