### PR TITLE
add delay to wait helm-operator

### DIFF
--- a/roles/decapod/tasks/helm-operator.yml
+++ b/roles/decapod/tasks/helm-operator.yml
@@ -41,6 +41,8 @@
   shell: >-
     {{ bin_dir }}/kubectl wait --namespace=kube-system --for=condition=Ready pods --selector name=helm-operator --timeout=600s
   become: false
+  delay: 10
+  retries: 3
 
 - name: delete helm-operator by-products
   file:


### PR DESCRIPTION
* kubectl apply 한 다음, delay 없이 바로 kubectl wait 명령어를 실행하면k8s resource not found 에러가 발생할 확률이 있다. 
* 최근 jenkins job이 이로 인해 실패함