### PR TITLE
Override k8s version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       defaultValue: 'gate-centos-lb-ceph-online-aio',
       description: 'target site(inventory) to deploy taco')
     string(name: 'K8S_VERSION',
-      defaultValue: 'v1.18.9',
+      defaultValue: 'v1.18.8',
       description: 'Kubernetes version to deploy')
     string(name: 'OS',
       defaultValue: 'centos7',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,7 @@ pipeline {
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@$ADMIN_NODE "cd tacoplay && git status && ansible-playbook -T 30 -vv -u taco -b -i inventory/${params.SITE}/hosts.ini site.yml -e @inventory/${params.SITE}/extra-vars.yml ${tacoplay_params}"
           """
           // Store k8s endpoint to file
-          sh "echo ${vmNamePrefix} > k8s_vm_\$(date +%y%m%d)"
+          sh "echo ${vmNamePrefix} > /tmp/k8s_vm_\$(date +%y%m%d)"
         }
       }
     }

--- a/roles/decapod/tasks/helm-operator.yml
+++ b/roles/decapod/tasks/helm-operator.yml
@@ -37,6 +37,10 @@
     {{ bin_dir }}/kubectl apply -f /tmp/.helm-operator-kustomization.yaml -n kube-system
   become: false
 
+- name: sleep for 5 seconds for helm-operator to be launched
+  wait_for:
+    timeout: 5
+
 - name: wait for helm-operator pod becomes ready
   shell: >-
     {{ bin_dir }}/kubectl wait --namespace=kube-system --for=condition=Ready pods --selector name=helm-operator --timeout=600s

--- a/site.yml
+++ b/site.yml
@@ -99,7 +99,6 @@
   roles:
     - { role: kubespray/roles/kubespray-defaults, tags: deploy }
     - { role: taco-apps/openstack/pre-install, tags: openstack, when: '"openstack" in taco_apps' }
-    - { role: taco-apps/deploy, tags: deploy, when: 'taco_apps and taco_apps|length > 0' }
 
 - name: run opentackclient container and make os_clients.sh file for user
   hosts: admin-node

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -25,9 +25,6 @@
   hosts: admin-node
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
+    - { role: kubespray/roles/kubespray-defaults, tags: k8s-post-install }
     - { role: k8s/post-install, tags: k8s-post-install }
-    - { role: k8s/client/kubectl, tags: k8s-post-install }
-    - { role: k8s/client/helm, vars: { helm_binary_name: helm3 }, tags: k8s-post-install }
-    - { role: k8s/helmv2/install, tags: helmv2, when: use_helmv2_for_armada }
-    - { role: k8s/client/helm, vars: { helm_binary_name: helm2 }, tags: helmv2, when: use_helmv2_for_armada }
-    - { role: k8s/helmv2/tiller, tags: helmv2, when: use_helmv2_for_armada }
+    - { role: k8s/clients, tags: taco-clients }


### PR DESCRIPTION
K8S Upgrade 테스트를 수행하기 위해 Tacoplay 수행시 kubernetes version을 지정해서 수행 가능해야 하며, 배포 완료 후에는 k8s cluster가 설치된 VM 이름을 file로 저장하여, 후속 Job인 deploy-apps 에서 해당 VM에 바로 App들을 설치할 수 있도록 한다.

메인 이슈 링크: openinfradev/hanu-ci-jobs#9

(실수로 jenkins 유저로 로그인하여 작성하였습니다. -robertchoi80)