### PR TITLE
Docker registry proxy

### DIFF
--- a/defaults/global_taco.yml
+++ b/defaults/global_taco.yml
@@ -58,3 +58,6 @@ versions_taco_istio: "./roles/taco-apps/istio/deploy/defaults/main.yml"
 versions_kubespray_docker: "./kubespray/roles/container-engine/docker/defaults/main.yml"
 taco_version: "v20.08"
 version_namespace: "default"
+
+# Container registry proxy
+container_registry_proxy_enabled: false

--- a/extra-playbooks/site-prepare.yml
+++ b/extra-playbooks/site-prepare.yml
@@ -8,6 +8,7 @@
     - { role: ../kubespray/roles/kubespray-defaults }
     - { role: ../kubespray/roles/container-engine }
     - { role: container-registry/client }
+    - { role: container-registry/proxy }
   tags: always
 
 - import_playbook: ../kubespray/cluster.yml

--- a/extra-playbooks/site-prepare.yml
+++ b/extra-playbooks/site-prepare.yml
@@ -8,7 +8,7 @@
     - { role: ../kubespray/roles/kubespray-defaults }
     - { role: ../kubespray/roles/container-engine }
     - { role: container-registry/client }
-    - { role: container-registry/proxy }
+    - { role: container-registry/proxy, when: container_registry_proxy_enabled}
   tags: always
 
 - import_playbook: ../kubespray/cluster.yml

--- a/roles/container-registry/proxy/defaults/main.yml
+++ b/roles/container-registry/proxy/defaults/main.yml
@@ -1,4 +1,3 @@
-container_registry_proxy_enabled: false
 container_registry_proxy_cert_dir: "{{ playbook_dir }}/proxy/certs"
 container_registry_proxy_cache_dir: "{{ playbook_dir }}/proxy/caches"
 container_registry_option_dir: "/etc/systemd/system/docker.service.d"

--- a/roles/container-registry/proxy/defaults/main.yml
+++ b/roles/container-registry/proxy/defaults/main.yml
@@ -1,0 +1,16 @@
+container_registry_proxy_enabled: false
+container_registry_proxy_cert_dir: "{{ playbook_dir }}/proxy/certs"
+container_registry_proxy_cache_dir: "{{ playbook_dir }}/proxy/caches"
+container_registry_option_dir: "/etc/systemd/system/docker.service.d"
+container_registry_proxy_name: "docker-registry-proxy"
+container_registry_proxy_image_repo: "sktdev/docker-registry-proxy"
+container_registry_proxy_image_tag: "0.6.3-taco"
+container_registry_proxy_env:
+  ENABLE_MANIFEST_CACHE: "true"
+  CACHE_MAX_SIZE: "1024g"
+container_registry_proxy_expose:
+  - "3128"
+container_registry_proxy_ports: 
+  - 3128:3128
+container_registry_proxy: "http://{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}:{{ container_registry_proxy_expose[0] }}"
+docker_bin_dir: "/usr/bin"

--- a/roles/container-registry/proxy/handlers/main.yml
+++ b/roles/container-registry/proxy/handlers/main.yml
@@ -1,0 +1,23 @@
+---
+- name: restart docker
+  command: /bin/true
+  notify:
+    - Docker | reload systemd
+    - Docker | reload docker
+    - Docker | wait for docker
+
+- name: Docker | reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: Docker | reload docker
+  service:
+    name: docker
+    state: restarted
+
+- name: Docker | wait for docker
+  command: "{{ docker_bin_dir }}/docker images"
+  register: docker_ready
+  retries: 20
+  delay: 1
+  until: docker_ready.rc == 0

--- a/roles/container-registry/proxy/tasks/main.yml
+++ b/roles/container-registry/proxy/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: install certain python modules for docker
+  pip:
+    name: "{{ item.name }}"
+    state: present
+    executable: pip3
+    extra_args: --ignore-installed
+  with_items:
+  - { name: docker }
+
+- name: docker-registry-proxy | create directory for cert
+  file:
+    path: "{{ container_registry_proxy_cert_dir }}"
+    state: directory
+  when:
+    - container_registry_proxy_enabled
+
+- name: docker-registry-proxy | create directory for image caches
+  file:
+    path: "{{ container_registry_proxy_cache_dir }}"
+    state: directory
+  when:
+    - container_registry_proxy_enabled
+
+- name: docker-registry-proxy | run docker registry proxy container
+  docker_container:
+    name: "{{ container_registry_proxy_name }}"
+    image: "{{ container_registry_proxy_image_repo }}:{{ container_registry_proxy_image_tag }}"
+    env: "{{ container_registry_proxy_env }}"
+    exposed_ports: "{{ container_registry_proxy_expose }}"
+    ports: "{{ container_registry_proxy_ports }}"
+    volumes:
+      - "{{ container_registry_proxy_cache_dir }}:/docker_mirror_cache"
+      - "{{ container_registry_proxy_cert_dir }}:/ca"
+    restart_policy: always
+    state: started
+  when: container_registry_proxy_enabled
+
+- name: docker-registry-proxy | create docker directory for systemd
+  file:
+    path: "{{ container_registry_option_dir }}"
+    state: directory
+  when:
+    - container_registry_proxy_enabled
+
+- name: docker-registry-proxy | Add environment vars pointing Docker to use the proxy
+  template:
+    src: docker-registry-proxy.conf.j2
+    dest: "{{ container_registry_option_dir }}/docker-registry-proxy.conf"
+  notify: restart docker
+  when: container_registry_proxy_enabled
+
+- name: docker-registry-proxy | Get the CA certificate from the proxy and make it a trusted root.
+  get_url:
+    url: "{{ container_registry_proxy }}/ca.crt"
+    dest: "/etc/pki/ca-trust/source/anchors/docker_registry_proxy.crt"
+    mode: '0440'
+  when: container_registry_proxy_enabled
+
+- name: Make CA certificate from the proxy a trusted root.
+  command: update-ca-trust
+  when: container_registry_proxy_enabled
+
+- meta: flush_handlers

--- a/roles/container-registry/proxy/tasks/main.yml
+++ b/roles/container-registry/proxy/tasks/main.yml
@@ -12,15 +12,11 @@
   file:
     path: "{{ container_registry_proxy_cert_dir }}"
     state: directory
-  when:
-    - container_registry_proxy_enabled
 
 - name: docker-registry-proxy | create directory for image caches
   file:
     path: "{{ container_registry_proxy_cache_dir }}"
     state: directory
-  when:
-    - container_registry_proxy_enabled
 
 - name: docker-registry-proxy | run docker registry proxy container
   docker_container:
@@ -34,31 +30,25 @@
       - "{{ container_registry_proxy_cert_dir }}:/ca"
     restart_policy: always
     state: started
-  when: container_registry_proxy_enabled
 
 - name: docker-registry-proxy | create docker directory for systemd
   file:
     path: "{{ container_registry_option_dir }}"
     state: directory
-  when:
-    - container_registry_proxy_enabled
 
 - name: docker-registry-proxy | Add environment vars pointing Docker to use the proxy
   template:
     src: docker-registry-proxy.conf.j2
     dest: "{{ container_registry_option_dir }}/docker-registry-proxy.conf"
   notify: restart docker
-  when: container_registry_proxy_enabled
 
 - name: docker-registry-proxy | Get the CA certificate from the proxy and make it a trusted root.
   get_url:
     url: "{{ container_registry_proxy }}/ca.crt"
     dest: "/etc/pki/ca-trust/source/anchors/docker_registry_proxy.crt"
     mode: '0440'
-  when: container_registry_proxy_enabled
 
 - name: Make CA certificate from the proxy a trusted root.
   command: update-ca-trust
-  when: container_registry_proxy_enabled
 
 - meta: flush_handlers

--- a/roles/container-registry/proxy/templates/docker-registry-proxy.conf.j2
+++ b/roles/container-registry/proxy/templates/docker-registry-proxy.conf.j2
@@ -1,2 +1,7 @@
+{% if container_registry_proxy is defined %}
 [Service]
-Environment={% if container_registry_proxy is defined %}"HTTP_PROXY={{ container_registry_proxy }}"{% endif %} {% if container_registry_proxy is defined %}"HTTPS_PROXY={{ container_registry_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}
+Environment="HTTP_PROXY={{ container_registry_proxy }}"
+Environment="HTTPS_PROXY={{ container_registry_proxy }}"{% endif %}
+{% if no_proxy is defined %}
+Environment="NO_PROXY={{ no_proxy }}"
+{% endif %}

--- a/roles/container-registry/proxy/templates/docker-registry-proxy.conf.j2
+++ b/roles/container-registry/proxy/templates/docker-registry-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if container_registry_proxy is defined %}"HTTP_PROXY={{ container_registry_proxy }}"{% endif %} {% if container_registry_proxy is defined %}"HTTPS_PROXY={{ container_registry_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}

--- a/roles/prepare-artifact/defaults/main.yml
+++ b/roles/prepare-artifact/defaults/main.yml
@@ -4,6 +4,9 @@ is_gating_test: false
 # Set this to 'true' to exclude k8s component images in site-prepare job
 exclude_k8s_images: false
 
+# save container image to local registry
+local_registry_enabled: false
+
 rbd_provisioner_image_repo: "docker.io/sktdev/rbd-provisioner"
 rbd_provisioner_image_tag: "v2.1.1-nautilus-14.2.4"
 openstackclient_image_repo: "docker.io/sktdev/openstackclient"

--- a/roles/prepare-artifact/tasks/main.yml
+++ b/roles/prepare-artifact/tasks/main.yml
@@ -34,22 +34,26 @@
       - 5000:5000
     volumes:
       - "{{ container_registry_volume_relative_dir }}:/var/lib/registry"
+  when: local_registry_enabled
 
 - name: tag images
   script: "{{ playbook_dir | dirname }}/scripts/tag-images.sh"
   args:
     creates: /tmp/.image-tag-done
+  when: local_registry_enabled
 
 - name: push tagged images to registry
   script: "{{ playbook_dir | dirname }}/scripts/push-images.sh"
   args:
     creates: /tmp/.image-push-done
+  when: local_registry_enabled
 
 - name: archive registry image
   docker_image:
     name: "{{ container_registry_image_repo }}"
     tag: "{{ container_registry_image_tag }}"
     archive_path: "{{ container_registry_volume_relative_dir }}/registry.tar"
+  when: local_registry_enabled
 
 - name: bundle up tacoplay
   shell: tar cvfz tacoplay.tar.gz tacoplay/


### PR DESCRIPTION
site-prepare 실행 시 docker 설치 후 docker-proxy-registry를 설치/설정하여, 그 이후 pull되는 이미지는 모두 docker-proxy-registry에 caching되도록한다.
