### PR TITLE
decapod: add argocd for v2

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -4,3 +4,4 @@ kubespray https://github.com/openinfradev/kubespray.git v2.14.0
 ceph-ansible https://github.com/openinfradev/ceph-ansible.git stable-4.0
 #charts/helm https://github.com/openinfradev/helm-charts.git master
 charts/taco-helm https://github.com/openinfradev/taco-helm.git main
+charts/argo-helm https://github.com/argoproj/argo-helm.git master

--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -19,3 +19,11 @@ argo_client_url: "https://github.com/argoproj/argo/releases/download/{{ argo_ver
 argo_workflow_archive_enabled: true
 argo_archive_storage_size: 8Gi
 argo_node_selector: null
+
+argocd_version: "v2.0.0"
+argocd_chart_source: "{{ lookup('env', 'HOME') }}/tacoplay/charts/argo-helm/charts/argo-cd"
+argocd_app_ctrl_replicas: 1
+argocd_server_replicas: 2
+argocd_repo_server_replicas: 2
+argocd_client_binary_name: "argocd-linux-amd64"
+argocd_client_url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocd_version }}/{{ argocd_client_binary_name }}"

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -1,0 +1,59 @@
+---
+- name: create namespace to deploy argo
+  shell: >-
+    {{ bin_dir }}/kubectl create namespace argo
+  ignore_errors: true
+  become: false
+
+- name: get redis-ha chart verion for argo-cd chart
+  shell: >-
+    grep version {{ argocd_chart_source }}/Chart.yaml  | tail -1 | awk '{print $2}'
+  register: redis_ha_chart_version
+
+- name: create sub-chart directory in argo-cd chart
+  file:
+    path: "{{ argocd_chart_source }}/charts"
+    state: directory
+  become: false
+
+- name: download redis-ha chart for argo-cd chart
+  shell: >-
+    cd {{ argocd_chart_source }}/charts && curl -sLO http://dandydeveloper.github.io/charts/redis-ha-{{ redis_ha_chart_version.stdout }}.tgz
+  become: false
+
+- name: install argo-cd chart
+  shell: >-
+    {{ bin_dir }}/helm install decapod-argocd {{ argocd_chart_source }} -n argo \
+    --set installCRDs=false \
+    --set controller.replicas={{ argocd_app_ctrl_replicas }} \
+    --set repoServer.replicas={{ argocd_repo_server_replicas }} \
+    --set server.replicas={{ argocd_server_replicas }}
+  become: false
+
+- name: sleep for 30 seconds for argo-cd pods to be launched
+  wait_for:
+    timeout: 30
+
+- name: wait for argo-cd pods become ready
+  shell: >-
+    {{ bin_dir }}/kubectl wait --namespace=argo --for=condition=Ready pods -l app.kubernetes.io/name={{ item }} --timeout=600s
+  become: false
+  delay: 10
+  retries: 3
+  with_items:
+    - argocd-dex-server
+    - argocd-redis
+    - argocd-application-controller
+    - argocd-repo-server
+    - argocd-server
+
+- name: check argocd client exists
+  stat:
+    path: "{{ bin_dir }}/argocd"
+  register: stat_result
+
+- name: install argo-cd client
+  shell: >-
+    cd /tmp && curl -sLO {{ argocd_client_url }} && chmod +x {{ argocd_client_binary_name }} && mv ./{{ argocd_client_binary_name }} {{ bin_dir }}/argocd
+  become: true
+  when: not stat_result.stat.exists

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - import_tasks: helm-operator.yml
 - import_tasks: argo.yml
+- import_tasks: argocd.yml
 
 - name: git clone decapod-flow
   git:


### PR DESCRIPTION
기존 decapod role에 추가로 argocd 설치하는 태스크를 추가
- [argo-helm](https://github.com/argoproj/argo-helm) 차트 사용
- application controller, argocd-repo-server, argocd-server POD 개수 설정 지원
