### PR TITLE
Argocd add an explicit target cluster

### DIFF
--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -28,6 +28,7 @@ argocd_repo_server_replicas: 2
 argocd_client_binary_name: "argocd-linux-amd64"
 argocd_client_url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocd_version }}/{{ argocd_client_binary_name }}"
 argocd_admin_password: "password"
+argocd_current_cluster_name: "hanu-reference"
 
 htpasswd_pkg_name_default: "httpd-tools"
 htpasswd_pkg_name_redhat: "httpd-tools"

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -61,11 +61,11 @@
   when: not stat_result.stat.exists
 
 - name: install htpasswd to create bcrypt hash for argocd admin user's password
-  package: name={{ htpasswd_pkg_name }}  state=latest
+  package: name={{ htpasswd_pkg_name }} state=latest
 
 - name: create bcrypt argocd admin's password hash
   shell: >-
-    htpasswd -nbBC 10 ADMIN password |  cut -d':' -f 2
+    htpasswd -nbBC 10 ADMIN {{ argocd_admin_password }} |  cut -d':' -f 2
   register: argocd_admin_password_hash
 
 - name: get password modified time

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -82,3 +82,28 @@
   shell: >-
     kubectl -n argo delete secret argocd-initial-admin-secret
   become: false
+
+- name: get one of the master node IP address
+  shell: >-
+     kubectl get no --selector=node-role.kubernetes.io/master -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | head -1
+  register: k8s_master_node_ip_addr
+  become: false
+
+- name: get nodePort of the argocd server service
+  shell: >-
+    kubectl get svc -n argo decapod-argocd-server -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
+  register: argocd_server_svc_nodeport
+  become: false
+
+- name: get current kuberetes cluster context
+  shell: >-
+    kubectl config view -o jsonpath='{.current-context}'
+  register: k8s_current_context
+  become: false
+
+- name: add an explicit target cluster context
+  shell: |
+    argocd login --insecure {{ k8s_master_node_ip_addr.stdout }}:{{ argocd_server_svc_nodeport.stdout }} --username admin --password {{ argocd_admin_password }}
+    argocd cluster add {{ k8s_current_context.stdout }} --name {{ argocd_current_cluster_name }} --upsert
+  become: false
+


### PR DESCRIPTION
기본적으로 생성되는 in-cluster 외에 현재 클러스터 컨텍스트를 argocd 클러스터 정보에 명시적으로 추가하는 부분을 추가하였습니다.
 - cluster 이름은 argocd_current_cluster_name 변수를 통해 설정할 수 있고 기본 값은 "taco-mgmt" 입니다.