### PR TITLE
TACODEV-801: support more late kubespray to support kubernetes v1.19.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ charts/
 mirrors/
 manifests/
 ironic-image/
+taco-gate-inventories/
+my-inventory/

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,4 @@
-kubespray https://github.com/openinfradev/kubespray.git v2.14.0
+kubespray https://github.com/openinfradev/kubespray.git v2.15.1
 #charts/openstack-helm https://github.com/openinfradev/openstack-helm.git master
 #charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git master
 ceph-ansible https://github.com/openinfradev/ceph-ansible.git stable-4.0


### PR DESCRIPTION
kubernetes 1.19.x 버전 지원을 위한 kubespray 최신 릴리즈로 변경