### PR TITLE
decapod/argocd: fix getting master node ip address

### DIFF
--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -85,7 +85,7 @@
 
 - name: get one of the master node IP address
   shell: >-
-     kubectl get no --selector=node-role.kubernetes.io/master -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | head -1
+     kubectl get no --selector=node-role.kubernetes.io/master -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' | awk '{print $1}'
   register: k8s_master_node_ip_addr
   become: false
 


### PR DESCRIPTION
argocd role에서 master 노드 아이피를 가져오는 부분의 오류를 수정하였습니다.