### PR TITLE
Use kubespray upstream repo

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,4 @@
-kubespray https://github.com/openinfradev/kubespray.git v2.15.1
+kubespray https://github.com/kubernetes-sigs/kubespray.git v2.15.1
 #charts/openstack-helm https://github.com/openinfradev/openstack-helm.git master
 #charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git master
 charts/taco-helm-charts https://github.com/openinfradev/helm-charts.git main


### PR DESCRIPTION
kubespray 저장소를 upstream (kubernetes-sigs/kubespray) 사용하는 것으로 변경하였습니다.