### PR TITLE
rook/decapod: fix retry wait task

### DIFF
--- a/roles/ceph/rook/tasks/main.yml
+++ b/roles/ceph/rook/tasks/main.yml
@@ -15,10 +15,6 @@
     {{ bin_dir }}/helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph
   become: false
 
-- name: sleep for 60 seconds for rook-operator pod to be launched
-  wait_for:
-    timeout: 60
-
 - name: wait for rook-operator pods become ready
   shell: >-
     {{ bin_dir }}/kubectl wait --namespace=rook-ceph --for=condition=Ready pods -l app={{ item }} --timeout=600s
@@ -27,6 +23,8 @@
   retries: 3
   with_items:
     - rook-ceph-operator
+  register: rook_ceph_operator_result
+  until: rook_ceph_operator_result is not failed
 
 - name: install rook ceph cluster chart
   shell: >-
@@ -37,13 +35,11 @@
     --set block_pools[0].requireSafeReplicaSize={{ rook_ceph_cluster_taco_pool_require_safe_size }}
   become: false
 
-- name: sleep for 300 seconds for rook ceph cluster to be initialized
-  wait_for:
-    timeout: 300
-
 - name: wait for rook ceph cluster become ready
   shell: >-
     {{ bin_dir }}/kubectl wait -n rook-ceph --for=condition=Ready cephcluster rook-ceph --timeout=600s
   become: false
   delay: 10
   retries: 3
+  register: rook_ceph_cluster_result
+  until: rook_ceph_cluster_result is not failed

--- a/roles/decapod/tasks/argo.yml
+++ b/roles/decapod/tasks/argo.yml
@@ -28,6 +28,8 @@
   with_items:
     - argo-server
     - workflow-controller
+  register: argo_pods_result
+  until: argo_pods_result is not failed
 
 - name: check argo client exists
   stat:

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -32,10 +32,6 @@
     --set "server.config.accounts\.admin=apiKey\, login" 
   become: false
 
-- name: sleep for 30 seconds for argo-cd pods to be launched
-  wait_for:
-    timeout: 30
-
 - name: wait for argo-cd pods become ready
   shell: >-
     {{ bin_dir }}/kubectl wait --namespace=argo --for=condition=Ready pods -l app.kubernetes.io/name={{ item }} --timeout=600s
@@ -48,6 +44,8 @@
     - argocd-application-controller
     - argocd-repo-server
     - argocd-server
+  register: argocd_pods_result
+  until: argocd_pods_result is not failed
 
 - name: check argocd client exists
   stat:

--- a/roles/decapod/tasks/helm-operator.yml
+++ b/roles/decapod/tasks/helm-operator.yml
@@ -37,16 +37,14 @@
     {{ bin_dir }}/kubectl apply -f /tmp/.helm-operator-kustomization.yaml -n kube-system
   become: false
 
-- name: sleep for 5 seconds for helm-operator to be launched
-  wait_for:
-    timeout: 5
-
 - name: wait for helm-operator pod becomes ready
   shell: >-
     {{ bin_dir }}/kubectl wait --namespace=kube-system --for=condition=Ready pods --selector name=helm-operator --timeout=600s
   become: false
   delay: 10
   retries: 3
+  register: helm_operator_result
+  until: helm_operator_result is not failed
 
 - name: delete helm-operator by-products
   file:


### PR DESCRIPTION
until 키워드가 누락되어서 실제로 해당 태스크가 반복되지 않는 문제를 수정했습니다.
참고: https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met