### PR TITLE
prepare-artifact: fix prometheusConfigReloaderImage tag

### DIFF
--- a/roles/prepare-artifact/defaults/main.yml
+++ b/roles/prepare-artifact/defaults/main.yml
@@ -25,4 +25,4 @@ decapod_preperation_site_name: "hanu-reference"
 # The following images were added because they cannot be processed
 # by tacoplay/scripts/download_container_images.py
 download_container_images:
-  - { repo: quay.io/prometheus-operator/prometheus-config-reloader, tag: v0.48.0}
+  - { repo: quay.io/prometheus-operator/prometheus-config-reloader, tag: v0.46.0}


### PR DESCRIPTION
수동으로 다운로드하는 prometheusConfigReloaderImage의 태그를 업스트림 kube-prometheus-stack 내용으로 잘못 참조했었습니다. 현재 TACO에서 사용하는 버전으로 수정합니다.