### PR TITLE
Decapod V1 관련 태스크 분리 및 온라인 환경 오류 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,9 @@ pipeline {
     string(name: 'SITE',
       defaultValue: 'gate-centos-lb-ceph-online-aio',
       description: 'target site(inventory) to deploy taco')
+    string(name: 'DECAPOD_VERSION',
+      defaultValue: 'main',
+      description: 'Decapod version: main or release-1.0')
     string(name: 'K8S_VERSION',
       defaultValue: 'v1.18.8',
       description: 'Kubernetes version to deploy. This will be ignored when offline deployment.')
@@ -228,7 +231,7 @@ pipeline {
         script {
           tacoplay_params = ""
           if (online) {
-            tacoplay_params = "-e kube_version=${params.K8S_VERSION}"
+            tacoplay_params = "-e kube_version=${params.K8S_VERSION} -e decapod_base_yaml_version=${params.DECAPOD_VERSION} -e decapod_site_version=${params.DECAPOD_VERSION} -e decapod_flow_version=${params.DECAPOD_VERSION}"
             // When offline deployment, all K8S binaries and images have already been prepared in the artifact file.
             // Therefore, kube_version parameter is ignored.
           }

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -33,18 +33,8 @@
     dest: "{{ decapod_flow_dest }}"
     version: "{{ decapod_flow_version }}"
   when: not stat_decapod_flow_dest.stat.exists
+  become: false
   tags: download
-
-- name: copy helmrelease-rbac.yaml to tmp
-  copy:
-    src: "{{ decapod_flow_dest }}/templates/helm-operator/helmrelease-rbac.yaml"
-    dest: "/tmp/.helmrelease-rbac.yaml"
-  become: false
-
-- name: install rbac to argo for helmrelase
-  shell: >-
-    {{ bin_dir }}/kubectl apply -f /tmp/.helmrelease-rbac.yaml
-  become: false
 
 - name: copy argo-additional-rbac.yaml to tmp
   copy:
@@ -57,56 +47,8 @@
     {{ bin_dir }}/kubectl apply -f /tmp/.argo-additional-rbac.yaml
   become: false
 
-- name: set facts for local helm repository IP address
-  set_fact:
-    local_helm_repo: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
-  with_items: "{{ groups['helm-repository'] | first }}"
-
-- name: set facts for local image registry hostname
-  set_fact:
-    local_image_registry: "{{ item }}"
-  with_items: "{{ groups['container-registry'] | first }}"
-
-- name: create manifest configmaps if {{ inventory_dir }} has *-manifest.yaml files
-  shell: >-
-    {{ playbook_dir }}/scripts/decapod/update_manifest_configmap.sh --helm-repo {{ local_helm_repo }} --image-registry {{ local_image_registry }} --inventory {{ inventory_dir }} --decapod_flow_dir {{ decapod_flow_dest }}
-  become: false
-
-- name: check deploy-helmrelease-wftpl is exist
-  shell: >-
-    {{ bin_dir }}/argo template get deploy-helmrelease -nargo
-  ignore_errors: true
-  register: shell_result
-  become: false
-
-- name: remove deploy-helmrelease wftpl
-  shell: >-
-    {{ bin_dir }}/argo template delete deploy-helmrelease -nargo
-  when: not shell_result.failed
-  become: false
-
-- name: summit helmrelease workflow template to argo
-  shell: >-
-    {{ bin_dir }}/argo template create {{ decapod_flow_dest }}/templates/helm-operator/helmrelease-wftpl.yaml -nargo
-  become: false
-
-- name: check prepare-manifest-wftpl is exist
-  shell: >-
-    {{ bin_dir }}/argo template get prepare-manifest -nargo
-  ignore_errors: true
-  register: shell_result
-  become: false
-
-- name: remove prepare-manifest wftpl
-  shell: >-
-    {{ bin_dir }}/argo template delete prepare-manifest -nargo
-  when: not shell_result.failed
-  become: false
-
-- name: summit prepare-manifest workflow template to argo
-  shell: >-
-    {{ bin_dir }}/argo template create {{ decapod_flow_dest }}/templates/decapod-yaml/prepare-manifest-wftpl.yaml -nargo
-  become: false
+- import_tasks: v1_tasks.yml
+  when: decapod_flow_version == "release-1.0"
 
 - name: delete decapod by-products
   file:

--- a/roles/decapod/tasks/v1_tasks.yml
+++ b/roles/decapod/tasks/v1_tasks.yml
@@ -1,0 +1,62 @@
+---
+- name: copy helmrelease-rbac.yaml to tmp
+  copy:
+    src: "{{ decapod_flow_dest }}/templates/helm-operator/helmrelease-rbac.yaml"
+    dest: "/tmp/.helmrelease-rbac.yaml"
+  become: false
+
+- name: install rbac to argo for helmrelase
+  shell: >-
+    {{ bin_dir }}/kubectl apply -f /tmp/.helmrelease-rbac.yaml
+  become: false
+
+- name: set facts for local helm repository IP address
+  set_fact:
+    local_helm_repo: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
+  with_items: "{{ groups['helm-repository'] | first }}"
+
+- name: set facts for local image registry hostname
+  set_fact:
+    local_image_registry: "{{ item }}"
+  with_items: "{{ groups['container-registry'] | first }}"
+
+- name: create manifest configmaps if {{ inventory_dir }} has *-manifest.yaml files
+  shell: >-
+    {{ playbook_dir }}/scripts/decapod/update_manifest_configmap.sh --helm-repo {{ local_helm_repo }} --image-registry {{ local_image_registry }} --inventory {{ inventory_dir }} --decapod_flow_dir {{ decapod_flow_dest }}
+  become: false
+
+- name: check deploy-helmrelease-wftpl is exist
+  shell: >-
+    {{ bin_dir }}/argo template get deploy-helmrelease -nargo
+  ignore_errors: true
+  register: shell_result
+  become: false
+
+- name: remove deploy-helmrelease wftpl
+  shell: >-
+    {{ bin_dir }}/argo template delete deploy-helmrelease -nargo
+  when: not shell_result.failed
+  become: false
+
+- name: summit helmrelease workflow template to argo
+  shell: >-
+    {{ bin_dir }}/argo template create {{ decapod_flow_dest }}/templates/helm-operator/helmrelease-wftpl.yaml -nargo
+  become: false
+
+- name: check prepare-manifest-wftpl is exist
+  shell: >-
+    {{ bin_dir }}/argo template get prepare-manifest -nargo
+  ignore_errors: true
+  register: shell_result
+  become: false
+
+- name: remove prepare-manifest wftpl
+  shell: >-
+    {{ bin_dir }}/argo template delete prepare-manifest -nargo
+  when: not shell_result.failed
+  become: false
+
+- name: summit prepare-manifest workflow template to argo
+  shell: >-
+    {{ bin_dir }}/argo template create {{ decapod_flow_dest }}/templates/decapod-yaml/prepare-manifest-wftpl.yaml -nargo
+  become: false

--- a/roles/decapod/tasks/v1_tasks.yml
+++ b/roles/decapod/tasks/v1_tasks.yml
@@ -13,17 +13,20 @@
 - name: set facts for local helm repository IP address
   set_fact:
     local_helm_repo: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
+  when: (groups['helm-repository'] | default([])) | length > 0
   with_items: "{{ groups['helm-repository'] | first }}"
 
 - name: set facts for local image registry hostname
   set_fact:
     local_image_registry: "{{ item }}"
+  when: (groups['container-registry'] | default([])) | length > 0
   with_items: "{{ groups['container-registry'] | first }}"
 
 - name: create manifest configmaps if {{ inventory_dir }} has *-manifest.yaml files
   shell: >-
     {{ playbook_dir }}/scripts/decapod/update_manifest_configmap.sh --helm-repo {{ local_helm_repo }} --image-registry {{ local_image_registry }} --inventory {{ inventory_dir }} --decapod_flow_dir {{ decapod_flow_dest }}
   become: false
+  when: local_helm_repo is defined and local_image_registry is defined
 
 - name: check deploy-helmrelease-wftpl is exist
   shell: >-


### PR DESCRIPTION
- Decapod V1/V2가 호환이 되지 않기 때문에 이를 지정해서 테스트할 수 있도록 Jenkins Job 변수를 추가하였습니다.
- V1 관련 태스크들을 별도로 분리하여 "release-1.0" 경우에만 실행되도록 하였습니다 (참고: v1 관련 내용들이 main 브랜치에서 제거됨 https://github.com/openinfradev/decapod-flow/commit/f4e6300ab198b2631b9e6cf247b218dc034c1d8e)
- V1 관련 추가된 오프라인 태스크 중 온라인 환경에서 오류가 발생할 수 있는 부분을 수정하였습니다: helm-repository, container-registry 그룹 및 호스트 정의가 안되어 있을 경우