### PR TITLE
fix decapod flow version

### DIFF
--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -5,7 +5,7 @@ bin_dir: /usr/local/bin
 decapod_enabled: true
 decapod_flow_source: "https://github.com/openinfradev/decapod-flow.git"
 decapod_flow_dest: "{{ role_path }}/files/decapod_flow"
-decapod_flow_version: "main"
+decapod_flow_version: "release-1.0"
 
 helm_operator_version: "v1.1.0"
 helm_operator_image_repo: "{{ docker_image_repo }}/fluxcd/helm-operator"


### PR DESCRIPTION
* decapod-flow main branch에서 v1관련 template들이 모두 삭제됨
* 아직 tacoplay는 decapod v2로 완전히 전환되지 않아 release-v1 branch를 쓰도록 변경