### PR TITLE
helm-repo: use get.helm.sh for chartmuseum url instead of s3

### DIFF
--- a/roles/helm-repository/defaults/main.yml
+++ b/roles/helm-repository/defaults/main.yml
@@ -3,7 +3,8 @@ helm_repo_enabled: true
 helm_repo_name: "taco-helm-repository"
 helm_repo_port: 8879
 
-chartmuseum_url: "https://s3.amazonaws.com/chartmuseum/release/latest/bin/linux/amd64/chartmuseum"
+chartmuseum_version: "v0.13.1"
+chartmuseum_url: "https://get.helm.sh/chartmuseum-{{ chartmuseum_version }}-linux-amd64.tar.gz"
 helm_servecm_url: "https://github.com/jdolitsky/helm-servecm"
 
 source_chart_base_dir: "{{ lookup('env', 'HOME') }}/tacoplay/charts"

--- a/roles/helm-repository/tasks/main.yml
+++ b/roles/helm-repository/tasks/main.yml
@@ -45,13 +45,13 @@
 
 - name: check chartmuseum binary exists
   stat:
-    path: "{{ role_path }}/files/chartmuseum"
+    path: "{{ role_path }}/files/chartmuseum.tar.gz"
   register: stat_chartmuseum_result
   tags: download
 
 - name: download chartmuseum binary
   shell: >-
-    curl -sL {{ chartmuseum_url }} -o {{ role_path }}/files/chartmuseum
+    curl -sL {{ chartmuseum_url }} -o {{ role_path }}/files/chartmuseum.tar.gz
   when: not stat_chartmuseum_result.stat.exists
   tags: download
 
@@ -67,8 +67,10 @@
   register: stat_result
 
 - name: install chartmuseum
-  shell: >-
-    chmod +x {{ role_path }}/files/chartmuseum && cp {{ role_path }}/files/chartmuseum {{ bin_dir }}/chartmuseum
+  shell: |
+    cd {{ role_path }}/files/
+    tar xvfz {{ role_path }}/files/chartmuseum.tar.gz
+    cp {{ role_path }}/files/linux-amd64/chartmuseum {{ bin_dir }}/chartmuseum
   become: true
   when: not stat_result.stat.exists
 


### PR DESCRIPTION
S3 다운로드가 무응답이 경우가 발생합니다. 업스트림 다운로드 URL인 get.helm.sh로 chartmuseum 다운로드 URL을 변경하였습니다.