### PR TITLE
prepare-artifact: fix jaeger images version

### DIFF
--- a/roles/prepare-artifact/defaults/main.yml
+++ b/roles/prepare-artifact/defaults/main.yml
@@ -33,3 +33,8 @@ download_container_images:
   - { repo: jaegertracing/jaeger-ingester, tag: 1.22.0 }
   - { repo: jaegertracing/jaeger-query, tag: 1.22.0 }
   - { repo: jaegertracing/all-in-one, tag: 1.22.0 }
+  - { repo: jaegertracing/jaeger-collector, tag: 1.21.0 }
+  - { repo: jaegertracing/jaeger-agent, tag: 1.21.0 }
+  - { repo: jaegertracing/jaeger-ingester, tag: 1.21.0 }
+  - { repo: jaegertracing/jaeger-query, tag: 1.21.0 }
+  - { repo: jaegertracing/all-in-one, tag: 1.21.0 }


### PR DESCRIPTION
decapod-site 1.0 오프라인 환경에서 설정한 이미지 버전 내용이 누락되어 있어 추가하였습니다.

참고: https://github.com/openinfradev/decapod-site/commit/655b01d47bbe1169e69e6d032d3014accb82ed75#diff-70166af36a6af4bb3bf20186a750d859bb18205de9b05ffff36c4e6abd2aea51