### PR TITLE
jenkins: always apply Decapod version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,14 +231,14 @@ pipeline {
         script {
           tacoplay_params = ""
           if (online) {
-            tacoplay_params = "-e kube_version=${params.K8S_VERSION} -e decapod_base_yaml_version=${params.DECAPOD_VERSION} -e decapod_site_version=${params.DECAPOD_VERSION} -e decapod_flow_version=${params.DECAPOD_VERSION}"
+            tacoplay_params = "-e kube_version=${params.K8S_VERSION}"
             // When offline deployment, all K8S binaries and images have already been prepared in the artifact file.
             // Therefore, kube_version parameter is ignored.
           }
           println("tacoplay_params: ${tacoplay_params}")
 
           sh """
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@$ADMIN_NODE "cd tacoplay && git status && ansible-playbook -T 30 -vv -u taco -b -i inventory/${params.SITE}/hosts.ini site.yml -e @inventory/${params.SITE}/extra-vars.yml ${tacoplay_params}"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@$ADMIN_NODE "cd tacoplay && git status && ansible-playbook -T 30 -vv -u taco -b -i inventory/${params.SITE}/hosts.ini site.yml -e @inventory/${params.SITE}/extra-vars.yml -e decapod_base_yaml_version=${params.DECAPOD_VERSION} -e decapod_site_version=${params.DECAPOD_VERSION} -e decapod_flow_version=${params.DECAPOD_VERSION} ${tacoplay_params}"
           """
           // Store k8s endpoint to file
           sh "echo ${vmNamePrefix} > /tmp/k8s_vm_\$(date +%y%m%d)"


### PR DESCRIPTION
v1 일 경우 분기하는 내용이 추가되었고 온/오프라인 관계없이 설정된 파라미터 값이 실제 플레이북 실행 시 적용이 되어야 하기 때문에 내용을 변경하였습니다.
참고: https://github.com/openinfradev/tacoplay/blob/5e02b72501b3b8803dd33194ff3f8277d7f23496/roles/decapod/tasks/main.yml#L51