### PR TITLE
update kubespray tag to fix local path provisioner

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,4 @@
-kubespray https://github.com/openinfradev/kubespray.git v2.15.1
+kubespray https://github.com/openinfradev/kubespray.git v2.15.1-local-path-fix
 #charts/openstack-helm https://github.com/openinfradev/openstack-helm.git master
 #charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git master
 charts/taco-helm-charts https://github.com/openinfradev/helm-charts.git main


### PR DESCRIPTION
local path provisioner 사용에 문제가 있어서 아래 2개를 업스트림에서 cherry-pick 하였습니다. (v2.16.0에 포함됨, 저희가 사용 중인 버전은 v2.15.1)

- https://github.com/openinfradev/kubespray/commit/e864043f4b4e8b07ad963bc5201401416dc943d6
- https://github.com/openinfradev/kubespray/commit/d3d9f78db0b62db777f71f95b002c3a888da0760