### PR TITLE
decapod: fix argo client install

### DIFF
--- a/roles/decapod/tasks/argo.yml
+++ b/roles/decapod/tasks/argo.yml
@@ -55,7 +55,7 @@
 
 - name: install argo client
   shell: >-
-    gunzip {{ role_path }}/files/{{ argo_client_binary_name }}.gz && chmod +x {{ role_path }}/files/{{ argo_client_binary_name }} && cp {{ role_path }}/files/{{ argo_client_binary_name }} {{ bin_dir }}/argo
+    gunzip {{ role_path }}/files/{{ argo_client_binary_name }}.gz -c > {{ role_path }}/files/{{ argo_client_binary_name }} && chmod +x {{ role_path }}/files/{{ argo_client_binary_name }} && cp {{ role_path }}/files/{{ argo_client_binary_name }} {{ bin_dir }}/argo
   become: true
   when: not stat_argo_bin_result.stat.exists
 


### PR DESCRIPTION
Gunzip은 in-place 업데이트로 기존 압축 파일이 삭제되기 때문에 오프라인 환경에서 플레이북 재실행 시 다시 외부에서 argo cli 바이너리를 다운로드 하려고 시도하는 문제가 발생합니다. 기존 압축 파일이 남아있도록 수정하였습니다.