### PR TITLE
 Fix sonobouy version being called automatically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,6 +252,7 @@ pipeline {
           def job = build(
             job: "validate-k8s",
             parameters: [
+              string(name: 'SONOBUOY_VERSION', value: "0.51.0"),
               string(name: 'KUBERNETES_CLUSTER_IP', value: "${ADMIN_NODE}"),
               string(name: 'SONOBUOY_MODE', value: params.SONOBUOY_MODE),
               booleanParam(name: 'OFFLINE_ENV', value: !online)


### PR DESCRIPTION
Changed to call sonobouy 0.51.0 in Jenkinsfile due to a bug that the
most recent version of sonobouy, 0.52.0, did not recognize the K8s
version properly. (#101)