### PR TITLE
decapod: add argocd installation option

### DIFF
--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -26,6 +26,7 @@ argo_mysql_version: "8"
 argo_archive_storage_size: 8Gi
 argo_node_selector: null
 
+argocd_enabled: false
 argocd_image_repo: "{{ quay_image_repo }}/argoproj/argocd"
 argocd_version: "v2.0.0"
 argocd_chart_source: "{{ role_path}}/../../charts/argo-helm/charts/argo-cd"

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -20,6 +20,7 @@
 - import_tasks: helm-operator.yml
 - import_tasks: argo.yml
 - import_tasks: argocd.yml
+  when: argocd_enabled
 
 - name: check if decapod_flow directory exists
   stat:


### PR DESCRIPTION
Decapod V1에서 argocd를 사용하지 않기 때문에 설치 여부를 설정할 수 있는 변수를 추가하였습니다.
V1을 사용하는 release-v21.06 브랜치에만 적용합니다.

[TACODEV-806](https://tde.sktelecom.com/pms/browse/TACODEV-806)
