### PR TITLE
TACODEV-774: enable metric on argo series

### DIFF
--- a/roles/decapod/tasks/argo.yml
+++ b/roles/decapod/tasks/argo.yml
@@ -5,23 +5,16 @@
   ignore_errors: true
   become: false
 
-- name: install argo chart
+- name: templating values file for argo-wf chart
+  template:
+    src: "{{ role_path }}/templates/argowf_values.j2"
+    dest: "{{ role_path }}/files/argowf.vo"
+  become: false
+
+- name: install argo-wf chart
   shell: >-
     {{ bin_dir }}/helm install argo {{ argo_chart_source }} -n argo \
-    --set workflowArchive.enabled={{ argo_workflow_archive_enabled }} \
-    --set mysql.enabled={{ argo_workflow_archive_enabled }} \
-    --set workflowController.image.repository={{ argo_workflow_controller_image_repo }} \
-    --set workflowController.image.tag={{ argo_version }} \
-    --set workflowController.executor.image.repository={{ argo_workflow_executor_image_repo }} \
-    --set workflowController.executor.image.tag={{ argo_version }} \
-    --set argoServer.image.repository={{ argo_server_image_repo }} \
-    --set argoServer.image.tag={{ argo_version }} \
-    --set nodeSelector={{ argo_node_selector }} \
-    --set mysql.image.repository={{ argo_mysql_image_repo }} \
-    --set mysql.image.tag={{ argo_mysql_version }} \
-    --set mysql.persistence.storageClass={{ taco_storageclass_name }} \
-    --set mysql.persistence.size={{ argo_archive_storage_size }} \
-    --set mysql.nodeSelector={{ argo_node_selector }}
+    -f {{ role_path }}/files/argowf.vo
   become: false
 
 - name: wait for argo pods become ready

--- a/roles/decapod/templates/argocd_values.j2
+++ b/roles/decapod/templates/argocd_values.j2
@@ -9,6 +9,8 @@ dex:
   image:
     repository: {{ argocd_dex_image_repo }}
     tag: {{ argocd_dex_version }}
+  metrics:
+    enabled: true
 
 redis:
   image:
@@ -17,12 +19,16 @@ redis:
 
 controller:
   replicas: {{ argocd_app_ctrl_replicas }}
+  metrics:
+    enabled: true
 
 repoServer:
   replicas: {{ argocd_repo_server_replicas }}
 
 server:
   replicas: {{ argocd_server_replicas }}
+  metrics:
+    enabled: true
   service:
     type: NodePort
   configEnabled: true

--- a/roles/decapod/templates/argowf_values.j2
+++ b/roles/decapod/templates/argowf_values.j2
@@ -1,0 +1,34 @@
+
+workflowArchive:
+  enabled: {{ argo_workflow_archive_enabled }} 
+workflowController:
+  image:
+    repository: {{ argo_workflow_controller_image_repo }} 
+    tag: {{ argo_version }} 
+  executor:
+    image:
+      repository: {{ argo_workflow_executor_image_repo }} 
+      tag: {{ argo_version }} 
+argoServer:
+  image:
+    repository: {{ argo_server_image_repo }} 
+    tag: {{ argo_version }} 
+nodeSelector: {{ argo_node_selector }} 
+mysql:
+  enabled: {{ argo_workflow_archive_enabled }} 
+  image:
+    repository: {{ argo_mysql_image_repo }} 
+    tag: {{ argo_mysql_version }} 
+  persistence:
+    storageClass: {{ taco_storageclass_name }} 
+    size: {{ argo_archive_storage_size }} 
+  nodeSelector: {{ argo_node_selector }}
+server:
+  servicePortName: http
+controller:
+  metricsConfig:
+  enabled: true
+  telemetryConfig:
+    enabled: true
+  metricsConfig:
+    enabled: true

--- a/roles/decapod/templates/argowf_values.j2
+++ b/roles/decapod/templates/argowf_values.j2
@@ -26,8 +26,6 @@ mysql:
 server:
   servicePortName: http
 controller:
-  metricsConfig:
-  enabled: true
   telemetryConfig:
     enabled: true
   metricsConfig:


### PR DESCRIPTION
**Objective**
Argo worflow/CD도 prometheus metric으로 수집할 수 있다. Argo worklfow/CD의 metric을 조사하고, Argo CD 의 주요 metric 수집한다.
argo cd/workflow exporter 존재함, 서비스 모니터 생성해서 prometheus로 데이터 저장 확인 (lma-addons) 
grafana dashboard 까지 추가, 확인 (grafana labs에 있는 대시보드 활용) 

**Doing with this PR**
argo 설치시 metric을 생성할 수 있도록 설정