### PR TITLE
Upgrade argo-workflow to v3

### DIFF
--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -15,6 +15,7 @@ argo_workflow_executor_image_registry: {{ quay_image_repo }}
 argo_workflow_executor_image_repo: "argoproj/argoexec"
 argo_workflow_server_image_registry: {{ quay_image_repo }}
 argo_workflow_server_image_repo: "argoproj/argocli"
+argo_workflow_server_service_type: "NodePort"
 
 #TODO: Currently not used values. Override these if necessary
 argo_workflow_server_node_selector: null

--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -9,11 +9,11 @@ decapod_flow_dest: "{{ role_path }}/files/decapod_flow"
 decapod_flow_version: "main"
 
 argo_workflow_version: "v3.1.0"
-argo_workflow_controller_image_registry: {{ quay_image_repo }}
+argo_workflow_controller_image_registry: "{{ quay_image_repo }}"
 argo_workflow_controller_image_repo: "argoproj/workflow-controller"
-argo_workflow_executor_image_registry: {{ quay_image_repo }}
+argo_workflow_executor_image_registry: "{{ quay_image_repo }}"
 argo_workflow_executor_image_repo: "argoproj/argoexec"
-argo_workflow_server_image_registry: {{ quay_image_repo }}
+argo_workflow_server_image_registry: "{{ quay_image_repo }}"
 argo_workflow_server_image_repo: "argoproj/argocli"
 argo_workflow_server_service_type: "NodePort"
 

--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -16,10 +16,11 @@ argo_workflow_executor_image_repo: "argoproj/argoexec"
 argo_workflow_server_image_registry: {{ quay_image_repo }}
 argo_workflow_server_image_repo: "argoproj/argocli"
 
+#TODO: Currently not used values. Override these if necessary
 argo_workflow_server_node_selector: null
 argo_workflow_controller_node_selector: null
 
-argo_workflow_controller_persistence_postgres_host: "172.16.50.85"
+argo_workflow_controller_persistence_postgres_host: ""
 argo_workflow_controller_persistence_postgres_port: 5432
 argo_workflow_controller_persistence_postgres_database: "postgres"
 argo_workflow_controller_persistence_postgres_tablename: "argo_workflows"

--- a/roles/decapod/defaults/main.yml
+++ b/roles/decapod/defaults/main.yml
@@ -3,22 +3,33 @@ quay_image_repo: "quay.io"
 
 bin_dir: /usr/local/bin
 decapod_enabled: true
+decapod_with_db_enabled: false
 decapod_flow_source: "https://github.com/openinfradev/decapod-flow.git"
 decapod_flow_dest: "{{ role_path }}/files/decapod_flow"
 decapod_flow_version: "main"
 
-argo_version: "v2.12.5"
-argo_server_image_repo: "{{ docker_image_repo }}/argoproj/argocli"
-argo_workflow_controller_image_repo: "{{ docker_image_repo }}/argoproj/workflow-controller"
-argo_workflow_executor_image_repo: "{{ docker_image_repo }}/argoproj/argoexec"
-argo_chart_source: "{{ role_path }}/../../charts/taco-helm-charts/argo"
-argo_client_binary_name: "argo-linux-amd64"
-argo_client_url: "https://github.com/argoproj/argo/releases/download/{{ argo_version }}/{{ argo_client_binary_name }}.gz"
+argo_workflow_version: "v3.1.0"
+argo_workflow_controller_image_registry: {{ quay_image_repo }}
+argo_workflow_controller_image_repo: "argoproj/workflow-controller"
+argo_workflow_executor_image_registry: {{ quay_image_repo }}
+argo_workflow_executor_image_repo: "argoproj/argoexec"
+argo_workflow_server_image_registry: {{ quay_image_repo }}
+argo_workflow_server_image_repo: "argoproj/argocli"
+
+argo_workflow_server_node_selector: null
+argo_workflow_controller_node_selector: null
+
+argo_workflow_controller_persistence_postgres_host: "172.16.50.85"
+argo_workflow_controller_persistence_postgres_port: 5432
+argo_workflow_controller_persistence_postgres_database: "postgres"
+argo_workflow_controller_persistence_postgres_tablename: "argo_workflows"
+argo_workflow_controller_persistence_postgres_secret: "postgres-secret"
+argo_workflow_offload_enabled: false
 argo_workflow_archive_enabled: true
-argo_mysql_image_repo: "{{ docker_image_repo }}/library/mysql"
-argo_mysql_version: "8"
-argo_archive_storage_size: 8Gi
-argo_node_selector: null
+
+argo_workflow_chart_source: "{{ role_path}}/../../charts/argo-helm/charts/argo-workflows"
+argo_client_binary_name: "argo-linux-amd64"
+argo_client_url: "https://github.com/argoproj/argo/releases/download/{{ argo_workflow_version }}/{{ argo_client_binary_name }}.gz"
 
 argocd_image_repo: "{{ quay_image_repo }}/argoproj/argocd"
 argocd_version: "v2.0.0"
@@ -29,11 +40,11 @@ argocd_repo_server_replicas: 2
 argocd_client_binary_name: "argocd-linux-amd64"
 argocd_client_url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocd_version }}/{{ argocd_client_binary_name }}"
 argocd_admin_password: "password"
-argocd_current_cluster_name: "hanu-reference"
 argocd_dex_image_repo: "{{ quay_image_repo }}/dexidp/dex"
 argocd_dex_version: "v2.26.0"
 argocd_redis_image_repo: "{{ docker_image_repo }}/library/redis"
 argocd_redis_version: "6.2.1-alpine"
+argocd_current_cluster_name: "{{ cluster_name }}"
 
 htpasswd_pkg_name_default: "httpd-tools"
 htpasswd_pkg_name_redhat: "httpd-tools"

--- a/roles/decapod/tasks/argo.yml
+++ b/roles/decapod/tasks/argo.yml
@@ -14,6 +14,7 @@
     --set executor.image.repository={{ argo_workflow_executor_image_repo }} \
     --set server.image.registry={{ argo_workflow_server_image_registry }} \
     --set server.image.repository={{ argo_workflow_server_image_repo }} \
+    --set server.serviceType={{ argo_workflow_server_service_type }} 
   become: false
 
 - name: wait for argo pods become ready

--- a/roles/decapod/tasks/argo.yml
+++ b/roles/decapod/tasks/argo.yml
@@ -5,34 +5,26 @@
   ignore_errors: true
   become: false
 
-- name: install argo chart
+- name: install argo-workflow chart
   shell: >-
-    {{ bin_dir }}/helm install argo {{ argo_chart_source }} -n argo \
-    --set workflowArchive.enabled={{ argo_workflow_archive_enabled }} \
-    --set mysql.enabled={{ argo_workflow_archive_enabled }} \
-    --set workflowController.image.repository={{ argo_workflow_controller_image_repo }} \
-    --set workflowController.image.tag={{ argo_version }} \
-    --set workflowController.executor.image.repository={{ argo_workflow_executor_image_repo }} \
-    --set workflowController.executor.image.tag={{ argo_version }} \
-    --set argoServer.image.repository={{ argo_server_image_repo }} \
-    --set argoServer.image.tag={{ argo_version }} \
-    --set nodeSelector={{ argo_node_selector }} \
-    --set mysql.image.repository={{ argo_mysql_image_repo }} \
-    --set mysql.image.tag={{ argo_mysql_version }} \
-    --set mysql.persistence.storageClass={{ taco_storageclass_name }} \
-    --set mysql.persistence.size={{ argo_archive_storage_size }} \
-    --set mysql.nodeSelector={{ argo_node_selector }}
+    {{ bin_dir }}/helm install argo-workflow {{ argo_workflow_chart_source }} -n argo \
+    --set controller.image.registry={{ argo_workflow_controller_image_registry }} \
+    --set controller.image.repository={{ argo_workflow_controller_image_repo }} \
+    --set executor.image.registry={{ argo_workflow_executor_image_registry }} \
+    --set executor.image.repository={{ argo_workflow_executor_image_repo }} \
+    --set server.image.registry={{ argo_workflow_server_image_registry }} \
+    --set server.image.repository={{ argo_workflow_server_image_repo }} \
   become: false
 
 - name: wait for argo pods become ready
   shell: >-
-    {{ bin_dir }}/kubectl wait --namespace=argo --for=condition=Ready pods -l app={{ item }} --timeout=600s
+    {{ bin_dir }}/kubectl wait --namespace=argo --for=condition=Ready pods -l app.kubernetes.io/name={{ item }} --timeout=600s
   become: false
   delay: 10
   retries: 3
   with_items:
-    - argo-server
-    - workflow-controller
+    - argo-workflows-server
+    - argo-workflows-workflow-controller
   register: argo_pods_result
   until: argo_pods_result is not failed
 
@@ -58,9 +50,3 @@
     gunzip {{ role_path }}/files/{{ argo_client_binary_name }}.gz -c > {{ role_path }}/files/{{ argo_client_binary_name }} && chmod +x {{ role_path }}/files/{{ argo_client_binary_name }} && cp {{ role_path }}/files/{{ argo_client_binary_name }} {{ bin_dir }}/argo
   become: true
   when: not stat_argo_bin_result.stat.exists
-
-- name: granting admin privileges into default serviceaccount
-  shell: >-
-    {{ bin_dir }}/kubectl create rolebinding default-admin --clusterrole=admin --serviceaccount=argo:default -n argo
-  become: false
-  ignore_errors: True

--- a/roles/decapod/tasks/argo_with_db.yml
+++ b/roles/decapod/tasks/argo_with_db.yml
@@ -1,0 +1,45 @@
+---
+- name: install argo-workflow chart with persistence config
+  shell: >-
+    {{ bin_dir }}/helm upgrade argo-workflow {{ argo_workflow_chart_source }} -n argo \
+    --set controller.image.registry={{ argo_workflow_controller_image_registry }} \
+    --set controller.image.repository={{ argo_workflow_controller_image_repo }} \
+    --set executor.image.registry={{ argo_workflow_executor_image_registry }} \
+    --set executor.image.repository={{ argo_workflow_executor_image_repo }} \
+    --set server.image.registry={{ argo_workflow_server_image_registry }} \
+    --set server.image.repository={{ argo_workflow_server_image_repo }} \
+    --set controller.persistence.postgresql.host={{ argo_workflow_controller_persistence_postgres_host }} \
+    --set controller.persistence.postgresql.port={{ argo_workflow_controller_persistence_postgres_port }} \
+    --set controller.persistence.postgresql.database={{ argo_workflow_controller_persistence_postgres_database }} \
+    --set controller.persistence.postgresql.tableName={{ argo_workflow_controller_persistence_postgres_tablename }} \
+    --set controller.persistence.postgresql.userNameSecret.name={{ argo_workflow_controller_persistence_postgres_secret }} \
+    --set controller.persistence.postgresql.userNameSecret.key="username" \
+    --set controller.persistence.postgresql.passwordSecret.name={{ argo_workflow_controller_persistence_postgres_secret }} \
+    --set controller.persistence.postgresql.passwordSecret.key="password" \
+    --set controller.persistence.nodeStatusOffload={{ argo_workflow_offload_enabled }} \
+    --set controller.persistence.archive={{ argo_workflow_archive_enabled }} \
+  become: false
+
+- name: wait for argo pods become ready
+  shell: >-
+    {{ bin_dir }}/kubectl wait --namespace=argo --for=condition=Ready pods -l app.kubernetes.io/name={{ item }} --timeout=600s
+  become: false
+  delay: 10
+  retries: 3
+  with_items:
+    - argo-workflows-server
+    - argo-workflows-workflow-controller
+  register: argo_pods_result
+  until: argo_pods_result is not failed
+
+- name: check argo client exists
+  stat:
+    path: "{{ bin_dir }}/argo"
+  register: stat_result
+
+- name: install argo client
+  shell: >-
+    cd /tmp && curl -sLO {{ argo_client_url }} && gunzip {{ argo_client_binary_name }}.gz && chmod +x {{ argo_client_binary_name }} && mv ./{{ argo_client_binary_name }} {{ bin_dir }}/argo
+  become: true
+  when: not stat_result.stat.exists
+

--- a/roles/decapod/tasks/argo_with_db.yml
+++ b/roles/decapod/tasks/argo_with_db.yml
@@ -8,6 +8,7 @@
     --set executor.image.repository={{ argo_workflow_executor_image_repo }} \
     --set server.image.registry={{ argo_workflow_server_image_registry }} \
     --set server.image.repository={{ argo_workflow_server_image_repo }} \
+    --set server.serviceType={{ argo_workflow_server_service_type }} \
     --set controller.persistence.postgresql.host={{ argo_workflow_controller_persistence_postgres_host }} \
     --set controller.persistence.postgresql.port={{ argo_workflow_controller_persistence_postgres_port }} \
     --set controller.persistence.postgresql.database={{ argo_workflow_controller_persistence_postgres_database }} \
@@ -17,7 +18,7 @@
     --set controller.persistence.postgresql.passwordSecret.name={{ argo_workflow_controller_persistence_postgres_secret }} \
     --set controller.persistence.postgresql.passwordSecret.key="password" \
     --set controller.persistence.nodeStatusOffload={{ argo_workflow_offload_enabled }} \
-    --set controller.persistence.archive={{ argo_workflow_archive_enabled }} \
+    --set controller.persistence.archive={{ argo_workflow_archive_enabled }} 
   become: false
 
 - name: wait for argo pods become ready

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -37,6 +37,7 @@
     dest: "{{ role_path }}/files/argocd.vo"
   become: false
 
+# TODO: should check if same helm release already exists
 - name: install argo-cd chart
   shell: >-
     {{ bin_dir }}/helm install decapod-argocd {{ argocd_chart_source }} -n argo \

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -15,8 +15,9 @@
     argocd_redis_version: "{{ argocd_redis_version }}"
   tags: download
 
-- import_tasks: argo.yml
-- import_tasks: argocd.yml
+- { import_tasks: argo.yml, when: decapod_enabled }
+- { import_tasks: argocd.yml, when: decapod_enabled }
+- { import_tasks: argo_with_db.yml, when: decapod_with_db_enabled }
 
 - name: check if decapod_flow directory exists
   stat:
@@ -50,4 +51,3 @@
     state: absent
   with_items:
     - "{{ decapod_flow_source }}"
-    - /tmp/.helmrelease-rbac.yaml

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: fail if decapod flags are both set
+  fail:
+    msg: "Error! Both decapod_enabled and decapod_with_db_enabled are set. Pick one!"
+  when:
+    - decapod_enabled
+    - decapod_with_db_enabled
+
 - name: set facts for prepare role
   set_fact:
     argo_version: "{{ argo_version }}"

--- a/roles/decapod/tasks/main.yml
+++ b/roles/decapod/tasks/main.yml
@@ -8,12 +8,13 @@
 
 - name: set facts for prepare role
   set_fact:
-    argo_version: "{{ argo_version }}"
+    argo_workflow_version: "{{ argo_workflow_version }}"
+    argo_workflow_controller_image_registry: "{{ argo_workflow_controller_image_registry }}"
     argo_workflow_controller_image_repo: "{{ argo_workflow_controller_image_repo }}"
+    argo_workflow_executor_image_registry: "{{ argo_workflow_executor_image_registry }}"
     argo_workflow_executor_image_repo: "{{ argo_workflow_executor_image_repo }}"
-    argo_server_image_repo: "{{ argo_server_image_repo }}"
-    argo_mysql_image_repo: "{{ argo_mysql_image_repo }}"
-    argo_mysql_version: "{{ argo_mysql_version }}"
+    argo_workflow_server_image_registry: "{{ argo_workflow_server_image_registry }}"
+    argo_workflow_server_image_repo: "{{ argo_workflow_server_image_repo }}"
     argocd_image_repo: "{{ argocd_image_repo }}"
     argocd_version: "{{ argocd_version }}"
     argocd_dex_image_repo: "{{ argocd_dex_image_repo }}"

--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -20,3 +20,10 @@
     - not allow_redeployment
     - stat_kubeconfig_result.stat.exists
     - stat_cc_result.rc == 0
+
+- name: fail if decapod flags are both set
+  fail:
+    msg: "Error! Both decapod_enabled and decapod_with_db_enabled are set. Pick one!"
+  when:
+    - decapod_enabled
+    - decapod_with_db_enabled

--- a/site.yml
+++ b/site.yml
@@ -45,7 +45,7 @@
     - { role: k8s/post-install, tags: k8s-post-install }
     - { role: k8s/clients, tags: k8s-post-install }
     - { role: ceph/rook, tags: rook,  when: taco_storage_backend == 'rook-ceph' }
-    - { role: decapod, tags: decapod, when: decapod_enabled }
+    - { role: decapod, tags: decapod, when: decapod_enabled or decapod_with_db_enabled }
 
 - name: setup helm repository
   hosts: helm-repository

--- a/site.yml
+++ b/site.yml
@@ -8,7 +8,7 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray/roles/kubespray-defaults, tags: setup-os }
-    - { role: validate-cluster, tags: setup-os }
+    - { role: validate, tags: setup-os }
 
 - name: setup host operating systems in taco host group
   hosts: taco


### PR DESCRIPTION
Argo-workflow 를 v3로 업그레이드함.

argocd와 마찬가지로 upstream chart를 사용하며, postgres DB 연동 여부에 따라 task를 두가지로 구분함
-argo.yml : DB 연동 없이 argo 설치 (decapod_enabled 시 수행)
-argo_with_db.yml : DB 연동하도록 config 추가하여 기존 helm release를 upgrade (decapod_with_db_enabled 시 수행)

초기 구축 시는 DB 없이 설치하고, decapod를 통해 keycloak 및 postgres 등이 설치되고 나면 위의 flag만 바꾸어서 다시 DB 연동 작업을 추가 수행하는 flow임

둘 중 하나의 flag만 true가 되도록 validation 로직 집어넣음.
- 초반의 validate role 에 넣고, decapod tag만 별도 수행하는 경우를 위해 decapod role에도 똑같이 넣음.
