### PR TITLE
Rook fix images and add host networking

### DIFF
--- a/roles/ceph/rook/defaults/main.yml
+++ b/roles/ceph/rook/defaults/main.yml
@@ -24,4 +24,5 @@ rook_ceph_version: v15.2.13
 rook_ceph_cluster_chart_source: "{{ role_path }}/../../../charts/taco-helm-charts/rook-ceph-cluster"
 rook_ceph_cluster_mon_replicas: 3
 rook_ceph_cluster_taco_pool_size: 3
+rook_ceph_cluster_host_networking_enabled: "false"
 rook_ceph_cluster_taco_pool_require_safe_size: "true"

--- a/roles/ceph/rook/defaults/main.yml
+++ b/roles/ceph/rook/defaults/main.yml
@@ -4,21 +4,23 @@ docker_image_repo: "docker.io"
 quay_image_repo: "quay.io"
 
 rook_ceph_operator_chart_source: "{{ role_path }}/../../../charts/rook-ceph"
-rook_ceph_version: v1.6.2
-rook_ceph_image_repo: "{{ docker_image_repo }}/rook/ceph"
+rook_ceph_operator_version: v1.6.7
+rook_ceph_operator_image_repo: "{{ docker_image_repo }}/rook/ceph"
 rook_cephcsi_image_repo: "{{ quay_image_repo }}/cephcsi/cephcsi"
 rook_cephcsi_image_tag: v3.3.1
 rook_csi_snapshotter_image_repo: "{{ kube_image_repo }}/sig-storage/csi-snapshotter"
-rook_csi_snapshotter_tag: v4.0.0
+rook_csi_snapshotter_tag: v4.1.1
 rook_csi_attacher_image_repo: "{{ kube_image_repo }}/sig-storage/csi-attacher"
-rook_csi_attacher_image_tag: v3.0.2
+rook_csi_attacher_image_tag: v3.2.1
 rook_csi_provisioner_image_repo: "{{ kube_image_repo}}/sig-storage/csi-provisioner"
-rook_csi_provisioner_image_tag: v2.0.4
+rook_csi_provisioner_image_tag: v2.2.2
 rook_csi_resizer_image_repo: "{{ kube_image_repo }}/sig-storage/csi-resizer"
-rook_csi_resizer_image_tag: v1.0.1
+rook_csi_resizer_image_tag: v1.2.0
 rook_csi_node_driver_registrar_image_repo: "{{ kube_image_repo }}/sig-storage/csi-node-driver-registrar"
-rook_csi_node_driver_registrar_image_tag: v2.0.1
+rook_csi_node_driver_registrar_image_tag: v2.2.0
 
+rook_ceph_image_repo: "{{ docker_image_repo }}/ceph/ceph"
+rook_ceph_version: v15.2.13
 rook_ceph_cluster_chart_source: "{{ role_path }}/../../../charts/taco-helm-charts/rook-ceph-cluster"
 rook_ceph_cluster_mon_replicas: 3
 rook_ceph_cluster_taco_pool_size: 3

--- a/roles/ceph/rook/tasks/main.yml
+++ b/roles/ceph/rook/tasks/main.yml
@@ -68,6 +68,7 @@
     --set cluster.image.repository={{ rook_ceph_image_repo }} \
     --set cluster.image.tag={{ rook_ceph_version }} \
     --set cluster.mon.count={{ rook_ceph_cluster_mon_replicas }} \
+    --set cluster.network.hostNetworkingEnabled={{ rook_ceph_cluster_host_networking_enabled }} \
     --set block_pools[0].name=taco \
     --set block_pools[0].size={{ rook_ceph_cluster_taco_pool_size  }} \
     --set block_pools[0].requireSafeReplicaSize={{ rook_ceph_cluster_taco_pool_require_safe_size }} \

--- a/roles/ceph/rook/tasks/main.yml
+++ b/roles/ceph/rook/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: set facts for prepare role
   set_fact:
+    rook_ceph_operator_image_repo: "{{ rook_ceph_operator_image_repo }}"
+    rook_ceph_operator_version: "{{ rook_ceph_operator_version }}"
     rook_ceph_image_repo: "{{ rook_ceph_image_repo }}"
     rook_ceph_version: "{{ rook_ceph_version }}"
     rook_cephcsi_image_repo: "{{ rook_cephcsi_image_repo }}"
@@ -31,7 +33,7 @@
 
 - name: download rook-operator chart
   shell: >-
-    {{ bin_dir }}/helm pull rook-ceph --repo https://charts.rook.io/release --version {{ rook_ceph_version }} --untar --untardir {{ rook_ceph_operator_chart_source }}/..
+    {{ bin_dir }}/helm pull rook-ceph --repo https://charts.rook.io/release --version {{ rook_ceph_operator_version }} --untar --untardir {{ rook_ceph_operator_chart_source }}/..
   become: false
   tags: download
   when: not stat_rook_ceph_chart_source.stat.exists
@@ -39,8 +41,8 @@
 - name: install rook-operator chart
   shell: >-
     {{ bin_dir }}/helm install --namespace rook-ceph rook-ceph {{ rook_ceph_operator_chart_source }} \
-    --set image.repository={{ rook_ceph_image_repo }} \
-    --set image.tag={{ rook_ceph_version }} \
+    --set image.repository={{ rook_ceph_operator_image_repo }} \
+    --set image.tag={{ rook_ceph_operator_version }} \
     --set csi.cephcsi.image={{ rook_cephcsi_image_repo }}:{{ rook_cephcsi_image_tag }} \
     --set csi.registrar.image={{ rook_csi_node_driver_registrar_image_repo }}:{{ rook_csi_node_driver_registrar_image_tag }} \
     --set csi.provisioner.image={{ rook_csi_provisioner_image_repo }}:{{ rook_csi_provisioner_image_tag }} \

--- a/roles/prepare-artifact/tasks/download_artifacts.yml
+++ b/roles/prepare-artifact/tasks/download_artifacts.yml
@@ -75,6 +75,7 @@
     tag: "{{ item.tag }}"
     source: pull
   with_items:
+    - { repo: "{{ rook_ceph_operator_image_repo }}", tag: "{{ rook_ceph_operator_version }}" }
     - { repo: "{{ rook_ceph_image_repo }}", tag: "{{ rook_ceph_version }}" }
     - { repo: "{{ rook_cephcsi_image_repo }}", tag: "{{ rook_cephcsi_image_tag }}" }
     - { repo: "{{ rook_csi_snapshotter_image_repo }}", tag: "{{ rook_csi_snapshotter_tag }}" }


### PR DESCRIPTION
- rook 이미지 지정 오류 (rook-ceph operator와 rook-ceph 클러스터용 이미지가 혼용되어 있었음) 수정
- public/private(cluster) 네트워크 분리 지원을 위한 호스트 네트워크 사용 옵션 추가: https://github.com/rook/rook/blob/master/Documentation/ceph-advanced-configuration.md#osd-dedicated-network