### PR TITLE
decapod: argocd: fix how to obtain Redis chart version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ruamel.yaml==0.16.10
 
 # for taco
 docker
+yq

--- a/roles/decapod/tasks/argocd.yml
+++ b/roles/decapod/tasks/argocd.yml
@@ -5,9 +5,15 @@
   ignore_errors: true
   become: false
 
-- name: get redis-ha chart verion for argo-cd chart
+- name: get redis-ha chart index from argo-cd chart dependencies
   shell: >-
-    grep version {{ argocd_chart_source }}/Chart.yaml  | tail -1 | awk '{print $2}'
+    cat {{ argocd_chart_source }}/Chart.yaml | /usr/local/bin/yq | jq .dependencies | jq 'map(.name == "redis-ha") | index(true) '
+  register: redis_ha_chart_index
+  tags: download
+
+- name: get redis-ha chart verion for argo-cd chart
+  shell: |
+    cat {{ argocd_chart_source }}/Chart.yaml | /usr/local/bin/yq .dependencies[{{ redis_ha_chart_index.stdout }}].version
   register: redis_ha_chart_version
   tags: download
 


### PR DESCRIPTION
argocd가 의존하는 redis 차트의 버전 정보를 가져오는 부분이 아주 가벼운 가정을 기반으로 "매우" 허접하게 구현되어 있습니다.

argocd 차트의 Chart.yaml에 annotation으로 최근 commit 제목이 추가되고 있는데 https://github.com/argoproj/argo-helm/commit/783cb3e0290b1f8b5934f1dfb212dd1fbe16df02# 처럼 version이라는 단어가 추가되는 경우 redis 차트 버전을 가져오지 못하는 문제가 발생합니다.

~~구현했던 기본 가정 (version 항목은 2개만 존재, 2번째 것이 Redis)은 그대로 둔 상태로 위 경우에 발생했던 문제가 해결될 수 있도록 수정하였습니다.~~
yq (https://github.com/kislyuk/yq)를 사용해서 정확한 redis-ha 차트 버전을 가져오도록 수정하였습니다.