### PR TITLE
Rook add placement support

### DIFF
--- a/docs/ceph.md
+++ b/docs/ceph.md
@@ -1,120 +1,44 @@
 TACO에서 Ceph 사용을 위한 설정
 =============================
 
-tacoplay에서는 아래와 같은 Ceph 구성 및 사용을 지원한다.
-* Ceph 클러스터 신규 구축 후 사용: 공식 저장소나 내부 미러링 저장소를 통해 설치
-* 별도로 구축된 기존 Ceph 클러스터 사용
-* Ceph을 사용하지 않음
+tacoplay에서는 rook를 사용해서 Ceph 구축 작업을 수행한다.
 
-이 문서에서는 Ceph 구성과 관련된 부분만을 설명하며 저장소 구축, 연동 부분은 [내부 저장소 구축 및 사용하기](local-package-repo.md) 문서에서 다룬다.
+모든 워커 노드의 빈 디스크를 Ceph OSD 데몬을 위한 디스크로 사용하며 taco 라는 이름의 Pool을 생성하고 Kubernetes 연동을 위한 스토리지 클래스까지 자동으로 생성한다.
 
-* * *
-Ceph 클러스터 신규 구축 및 사용하는 경우
+### extra-vars.yml 설정
+| 설정 값 | 기본 값 | 설명 |
+|---------|---------|------|
+| rook_ceph_cluster_mon_replicas | 3 |  Ceph monitor 데몬 개수 |
+| rook_ceph_cluster_taco_pool_size | 3 | 기본 생성하는 Pool의 replica 개수 |
+| rook_ceph_cluster_host_networking_enabled | "false" | Ceph 데몬 POD 들이 호스트 네트워크 설정 사용 여부 |
+| rook_ceph_cluster_ceph_only_nodes_enabled | "false" | Ceph 전용 노드 구성 사용 여부 |
+| rook_ceph_cluster_taco_pool_require_safe_size | "true" | 기본 생성하는 Pool의 replica 설정의 사전 안정성 검사 여부 |
+
+Ceph 전용 노드를 사용하여 구축하는 경우
 -------------------------
 ### hosts.ini 설정
-Ceph를 설치하고자 하는 호스트를 아래 그룹에 배치한다.
-* [mons]: (필수) Monitor 데몬이 실행 (3대 권장)
-* [mgrs]: (필수) Manager 데몬이 실행 (mons와 동일하게 구성)
-* [osds]: (필수) 실제 데이터가 저장되는 OSD 데몬이 실행
-* [mdss]: (옵션) CephFS 메타데이터 데몬이 실행
+Kubernetes 워커 노드 중 일부를 Ceph 서비스 전용으로만 사용하려고 한다면 호스트 정의에 아래 내용을 추가한다.
+* 그룹 [ceph]: [kube-node] 워커 노드 중 Ceph 전용 노드로 사용할 노드를 정의
+* [ceph] 그룹 vars: 'role":"storage-node"' 노드 레이블 설정
+설정된 [ceph] 그룹 노드에 'storage-node=true:NoSchedule' Taint가 자동으로 추가된다.
+rook_ceph_cluster_ceph_only_nodes_enabled 변수를 true로 설정한다.
 
 **(예제)**
 ```
-[mons]
+[ceph]
 ceph-1
 ceph-2
 ceph-3
 
-[mgrs]
-ceph-1
-ceph-2
-ceph-3
-
-[osds]
-ceph-1
-ceph-2
-ceph-3
-ceph-4
+[ceph:vars]
+node_labels={"role":"storage-node"}
 ```
 
 ### extra-vars.yml 설정
-| 설정 값             | 설명                                       | 
-|---------------------|--------------------------------------------|
-| monitor_interface   | Ceph monitor 주소가 할당된 인터페이스 이름 |
-| public_network      | Ceph public network 대역                   |
-| cluster_network     | Ceph cluster network 대역                  |
-| lvm_volumes         | Ceph에서 사용할 lvm volume 목록            |
-| ceph_conf_overrides | Ceph 설정 파일인 ceph.conf에 추가할 내역   |
-| openstack_config    | Ceph Pool 및 사용자 생성 여부              |
-| openstack_pools     | 생성할 Ceph Pool 내역                      |
 
 **(예제)**
 ```
-monitor_interface: bond0
-public_network: 192.168.1.0/24
-cluster_network: 192.168.2.0/24
-ceph_conf_overrides:
-      global:
-        mon_allow_pool_delete: true
-        osd_pool_default_size: 1
-        osd_pool_default_min_size: 1
-openstack_config: true
-kube_pool:
-  name: "kube"
-  pg_num: 64
-  pgp_num: 64
-  type: 1
-  erasure_profile: ""
-  expected_num_objects: ""
-  application: "rbd"
-openstack_pools:
-  - "{{ kube_pool }}"
-```
-* * *
-
-기존 Ceph 클러스터 연동하는 경우
-------------------
-연동하고자 하는 Ceph 클러스터에 필요한 Pool과 사용자를 생성한다.
-* Kubernetes Persistent Volume용
-* OpenStack Glance용
-* OpenStack Cinder용
-* OpenStack Nova용
-
-### hosts.ini 설정
-Ceph 관련 그룹 정의는 그대로 두되 호스트는 비워둔다.
-
-**(예제)**
-```
-[mons]
-# empty
-
-[mgrs]
-# empty
-
-[osds]
-# empty
-```
-
-### extra-vars.yml 설정
-| 설정 값                     | 설명                                                    |
-|-----------------------------|---------------------------------------------------------|
-| ceph_monitors               | 연동하고자 하는 Ceph 클러스터의 Monitor IP 주소         |
-| ceph_admin_keyring          | 위Ceph 클러스터 client.admin의 Keyring                  |
-| rbd_provisioner_pool        | K8S Persistent 볼륨용 Pool의 이름                       |
-| rbd_provisioner_admin_id    | K8S Persistent 볼륨용 Pool에 접근할 Ceph User ID        |
-| rbd_provisioner_secret      | 위 Ceph User의 Keyring |
-| rbd_provisioner_user_id     | rbd_provisioner_admin_id와 동일한 값으로 설정|
-| rbd_provisioner_user_secret | rbd_provisioner_secret과동일한 값으로 설정|
-
-**(예제)**
-```
-ceph_monitors: "192.168.1.51,192.168.1.52,192.168.1,53"
-ceph_admin_keyring: 'AQD+3INa1wtjEhAAUFQ1xmhsc7PccAx0r+NGPA=='
-rbd_provisioner_pool: kube
-rbd_provisioner_admin_id: kube
-rbd_provisioner_secret: 'AQAPn8tUmPBwCxAAeIfvpDKA1fGvrBeXGdc6xQ=='
-rbd_provisioner_user_id: kube
-rbd_provisioner_user_secret: 'AQAPn8tUmPBwCxAAeIfvpDKA1fGvrBeXGdc6xQ=='
+rook_ceph_cluster_ceph_only_nodes_enabled: "true"
 ```
 
 * * *

--- a/inventory/sample/aio/hosts.ini
+++ b/inventory/sample/aio/hosts.ini
@@ -17,26 +17,12 @@ kube-node
 [kube-master:vars]
 node_labels={"openstack-control-plane":"enabled", "openstack-compute-node":"enabled", "linuxbridge":"enabled", "taco-lma":"enabled", "fluent-logging":"enabled"}
 
-# Ceph cluster
-# we need empty mons group or clients role fails
-[mons]
-taco-aio
-
-[mgrs]
-taco-aio
-
-[osds]
-taco-aio
-
-[clients:children]
-k8s-cluster
-admin-node
-
-[ceph:children]
-mgrs
-osds
-mons
-clients
+## Ceph cluster: if you want Ceph only nodes, use the following group and lables
+## XXX: Don't use this in the all-in-one environment.
+# [ceph]
+# ceph-node-01
+# [ceph:vars]
+# node_labels={"role":"storage-node"}
 
 # OpenStack cluster
 [controller-node]

--- a/roles/ceph/rook/defaults/main.yml
+++ b/roles/ceph/rook/defaults/main.yml
@@ -25,4 +25,5 @@ rook_ceph_cluster_chart_source: "{{ role_path }}/../../../charts/taco-helm-chart
 rook_ceph_cluster_mon_replicas: 3
 rook_ceph_cluster_taco_pool_size: 3
 rook_ceph_cluster_host_networking_enabled: "false"
+rook_ceph_cluster_ceph_only_nodes_enabled: "false"
 rook_ceph_cluster_taco_pool_require_safe_size: "true"

--- a/roles/ceph/rook/defaults/main.yml
+++ b/roles/ceph/rook/defaults/main.yml
@@ -4,7 +4,7 @@ docker_image_repo: "docker.io"
 quay_image_repo: "quay.io"
 
 rook_ceph_operator_chart_source: "{{ role_path }}/../../../charts/rook-ceph"
-rook_ceph_operator_version: v1.6.7
+rook_ceph_operator_version: v1.6.9
 rook_ceph_operator_image_repo: "{{ docker_image_repo }}/rook/ceph"
 rook_cephcsi_image_repo: "{{ quay_image_repo }}/cephcsi/cephcsi"
 rook_cephcsi_image_tag: v3.3.1
@@ -19,8 +19,8 @@ rook_csi_resizer_image_tag: v1.2.0
 rook_csi_node_driver_registrar_image_repo: "{{ kube_image_repo }}/sig-storage/csi-node-driver-registrar"
 rook_csi_node_driver_registrar_image_tag: v2.2.0
 
-rook_ceph_image_repo: "{{ docker_image_repo }}/ceph/ceph"
-rook_ceph_version: v15.2.13
+rook_ceph_image_repo: "{{ quay_image_repo }}/ceph/ceph"
+rook_ceph_version: v15.2.14
 rook_ceph_cluster_chart_source: "{{ role_path }}/../../../charts/taco-helm-charts/rook-ceph-cluster"
 rook_ceph_cluster_mon_replicas: 3
 rook_ceph_cluster_taco_pool_size: 3

--- a/roles/ceph/rook/tasks/main.yml
+++ b/roles/ceph/rook/tasks/main.yml
@@ -24,6 +24,15 @@
     {{ bin_dir }}/kubectl create namespace rook-ceph
   ignore_errors: true
   become: false
+  run_once: true
+
+- name: add a taint for Ceph services
+  shell: >-
+    {{ bin_dir }}/kubectl taint nodes {{ item }} storage-node=true:NoSchedule --overwrite
+  when:
+  - rook_ceph_cluster_ceph_only_nodes_enabled
+  with_items: "{{ groups['ceph'] }}"
+  run_once: true
 
 - name: check if rook-operator chart directory exists
   stat:
@@ -62,17 +71,16 @@
   register: rook_ceph_operator_result
   until: rook_ceph_operator_result is not failed
 
-- name: install rook ceph cluster chart
+- name: templating values file for rook-ceph-cluster chart
+  template:
+    src: "{{ role_path }}/templates/rook_ceph_cluster_values.j2"
+    dest: "{{ role_path }}/files/rook_ceph_cluster.vo"
+  become: false
+
+- name: install rook-ceph-cluster chart
   shell: >-
     {{ bin_dir }}/helm install --namespace rook-ceph rook-ceph-cluster {{ rook_ceph_cluster_chart_source }} \
-    --set cluster.image.repository={{ rook_ceph_image_repo }} \
-    --set cluster.image.tag={{ rook_ceph_version }} \
-    --set cluster.mon.count={{ rook_ceph_cluster_mon_replicas }} \
-    --set cluster.network.hostNetworkingEnabled={{ rook_ceph_cluster_host_networking_enabled }} \
-    --set block_pools[0].name=taco \
-    --set block_pools[0].size={{ rook_ceph_cluster_taco_pool_size  }} \
-    --set block_pools[0].requireSafeReplicaSize={{ rook_ceph_cluster_taco_pool_require_safe_size }} \
-    --set storageclass.name={{ taco_storageclass_name }}
+    -f {{ role_path }}/files/rook_ceph_cluster.vo
   become: false
 
 - name: wait for rook ceph cluster become ready

--- a/roles/ceph/rook/templates/rook_ceph_cluster_values.j2
+++ b/roles/ceph/rook/templates/rook_ceph_cluster_values.j2
@@ -1,0 +1,36 @@
+rook:
+  image:
+    repository: {{ rook_ceph_operator_image_repo }}
+    tag: {{ rook_ceph_operator_version }}
+
+cluster:
+  image:
+    repository: {{ rook_ceph_image_repo }}
+    tag: {{ rook_ceph_version }}
+  mon:
+    # should be odd number
+    count: {{ rook_ceph_cluster_mon_replicas }}
+  network:
+    hostNetworkingEnabled: {{ rook_ceph_cluster_host_networking_enabled }}
+  {% if rook_ceph_cluster_ceph_only_nodes_enabled -%}
+  placement:
+    all:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: role
+              operator: In
+              values:
+              - storage-node
+      tolerations:
+      - key: storage-node
+        operator: Exists
+  {% endif %}
+block_pools:
+  - name: taco
+    size: {{ rook_ceph_cluster_taco_pool_size }}
+    requireSafeReplicaSize: {{ rook_ceph_cluster_taco_pool_require_safe_size }}
+storageclass:
+  name: {{ taco_storageclass_name }}
+  pool: taco


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/73 변경 사항을 tacoplay에 적용하기 위한 것입니다.

Ceph 전용 노드로 사용하기 위해서 아래 2가지 사항이 추가됩니다.
1. Ceph 서비스 POD이 해당 노드로 스케쥴링 되기 위해서 'role":"storage-node' 노드 레이블 추가
2. 다른 POD이 해당 노드로 스케쥴링 되는 것을 막기 위해서 'storage-node=true:NoSchedule' 노드 테인트 추가

1번의 경우 kubespray node_labels 변수를 사용하였고 2번은 플레이북의 태스크로 구현하였습니다.
kubespray node_taints 라는 변수가 구축 과정에서 테인트 설정을 해주기 위해 존재하는데 kubectl 을 통하는 것이 아닌 kubelet의 파라미터로 지정하는 방식이라 운영 중에 변경 사항 (기존 노드를 Ceph 전용이 아닌 일반 노드로 전환, 기존 일반 노드를 Ceph 전용 노드로 전환)을 적용하기도 불편하고 kubectl을 사용한 방법과 혼재하는 경우가 발생할 수 있어 일관성을 위해 kubectl 을 사용하는 것으로 하였습니다.

