### PR TITLE
Support kube v1.22

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,9 @@ pipeline {
 
   stages {
     stage ('Prepare Tacoplay') {
+      environment {
+          GITHUB_TOKEN = credentials('hanu-github-token-new')
+      }
       steps {
           script {
             ADMIN_NODE = ''
@@ -82,7 +85,7 @@ pipeline {
             println("*********************************************")
 
             sh """
-              git clone https://github.com/openinfradev/taco-gate-inventories.git --branch ${params.GATING_INVENTORIES_TAG} --single-branch
+              git clone https://$GITHUB_TOKEN@github.com/openinfradev/taco-gate-inventories.git --single-branch -b $params.GATING_INVENTORIES_TAG
               cp -r taco-gate-inventories/inventories/${params.SITE} ./inventory/
               cp -r taco-gate-inventories/scripts ./gate-scripts
               cp taco-gate-inventories/config/pangyo-clouds.yml ./clouds.yaml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,11 +120,7 @@ pipeline {
               deleteBdm = true
 
               if (online) {
-                if (params.OS.contains("ubuntu")) {
-                  sh "mv gate-scripts/cloudInitUbuntuOnline.sh gate-scripts/cloudInit.sh"
-                } else {
                   sh "mv gate-scripts/cloudInitOnline.sh gate-scripts/cloudInit.sh"
-                }
               } else {
                 if (params.OS.contains("ubuntu")) {
                   sh "mv gate-scripts/cloudInitUbuntuOffline.sh gate-scripts/cloudInit.sh"

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,4 +1,4 @@
-kubespray https://github.com/openinfradev/kubespray.git v2.15.1-hanu
+kubespray https://github.com/kubernetes-sigs/kubespray.git v2.17.0
 #charts/openstack-helm https://github.com/openinfradev/openstack-helm.git master
 #charts/openstack-helm-infra https://github.com/openinfradev/openstack-helm-infra.git master
 charts/taco-helm-charts https://github.com/openinfradev/helm-charts.git main

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -8,7 +8,7 @@ Tacoplay ansible variables
 Inventory
 ---------------------
 tacoplay는 아래와 같은 inventory로 node를 group으로 구성한다.
-* [kube-master]: kubernetes master node들의 목록
+* [kube_control_plane]: kubernetes master node들의 목록
 * [etcd]: etcd cluster를 구성할 node들의 목록
 * [kube-node]: kubernetes worker node들의 목록
 * [k8s-cluster:children]: kubernetes cluster 목록의 묶음

--- a/docs/recover-k8s-control-plane.md
+++ b/docs/recover-k8s-control-plane.md
@@ -26,22 +26,22 @@ Kubernetes master 노드에서 아래 디렉티리와 파일을 백업한다.
 * /etc/kubernetes/ssl (디렉토리)
 * /etc/kubernetes/pki (심볼릭 링크)
 
-전체 노드 장애로 데이터 손실이 발생할 경우 복구 과정에서 백업 데이터가 필요하며 그 외의 경우에는 "etcd"와 "kube-master" 그룹의 첫 번째 노드 데이터를 기준으로 복구를 진행한다.
+전체 노드 장애로 데이터 손실이 발생할 경우 복구 과정에서 백업 데이터가 필요하며 그 외의 경우에는 "etcd"와 "kube_control_plane" 그룹의 첫 번째 노드 데이터를 기준으로 복구를 진행한다.
 
 ## 컨트롤 플레인 복구 절차
 
 * 신규 노드를 동일한 IP 주소를 가지도록 프로비저닝 한다.
 * hosts.ini 수정
-  * "etcd"와 "kube-master" 그룹의 첫번 째 노드에서 복구 작업이 수행되기 때문에 정상 동작하는 노드를 각 그룹의 첫 번째로 이동시킨다.
+  * "etcd"와 "kube_control_plane" 그룹의 첫번 째 노드에서 복구 작업이 수행되기 때문에 정상 동작하는 노드를 각 그룹의 첫 번째로 이동시킨다.
     * "etcd" 그룹의 경우 첫번 째 노드의 "etcd\_member\_name" 변수를 반드시 설정한다. 이전 구축 시 해당 변수를 설정하지 않았다면 그룹 내 노드 순서대로 etcd1, etcd2, etcd3와 같이 자동 설정되어 있다.
   * 장애가 발생한 etcd 노드를 "broken_etcd" 그룹으로 이동시키고 "etcd\_member\_name" 변수를 반드시 설정한다. 복구할 etcd 노드가 없더라도 "broken_etcd" 그룹 항목은 남겨둔다.
-  * 장애가 발생한 master 노드를 "broken\_kube-master" 그룹으로 이동시킨다. 복구한 master 노드가 없더라도 "broken\_kube-master" 그룹 항목은 남겨둔다.
-* master 노드 전체 장애일 경우 백업한 Kubernetes 인증서/키 파일을 "kube-master" 그룹의 첫 번째 노드에 동일한 위치로 복사하고 아래와 같이 /etc/kubernetes 디렉토리 보안 권한을 모두 해제한다.  `# chmod 777 /etc/kubernetes`
+  * 장애가 발생한 master 노드를 "broken\_kube_control_plane" 그룹으로 이동시킨다. 복구한 master 노드가 없더라도 "broken\_kube_control_plane" 그룹 항목은 남겨둔다.
+* master 노드 전체 장애일 경우 백업한 Kubernetes 인증서/키 파일을 "kube_control_plane" 그룹의 첫 번째 노드에 동일한 위치로 복사하고 아래와 같이 /etc/kubernetes 디렉토리 보안 권한을 모두 해제한다.  `# chmod 777 /etc/kubernetes`
 
 ### hosts.ini 수정 예제
 * 기본
 ```
-[kube-master]
+[kube_control_plane]
 taco-m1
 taco-m2
 taco-m3
@@ -56,7 +56,7 @@ taco-w2
 
 * 수정 후
 ```
-[kube-master]
+[kube_control_plane]
 taco-m1
 taco-m2
 taco-m3
@@ -73,19 +73,19 @@ taco-m1 etcd_member_name=etcd1
 taco-m2 etcd_member_name=etcd2
 taco-m3 etcd_member_name=etcd3
 
-[broken_kube-master]
+[broken_kube_control_plane]
 taco-m1
 taco-m2
 taco-m3
 ```
-다음과 같이 ```--limit etcd,kube-master```, ```-e etcd_retries=10```, ```--skip-tags=external-provisioner``` 옵션을 추가하여 플레이북을 실행한다.
+다음과 같이 ```--limit etcd,kube_control_plane```, ```-e etcd_retries=10```, ```--skip-tags=external-provisioner``` 옵션을 추가하여 플레이북을 실행한다.
 ```
-$ ansible-playbook -b -i inventory/sample/hosts.ini -e @inventory/sample/extra-vars.yml recover-k8s-control-plane.yml --limit etcd,kube-master -e etcd_retries=10 --skip-tags=external-provisioner
+$ ansible-playbook -b -i inventory/sample/hosts.ini -e @inventory/sample/extra-vars.yml recover-k8s-control-plane.yml --limit etcd,kube_control_plane -e etcd_retries=10 --skip-tags=external-provisioner
 ```
 
 etcd 백업 데이터를 사용할 경우 "etcd\_snapshot" 변수를 사용한다.
 ```
-$ ansible-playbook -b -i inventory/sample/hosts.ini -e @inventory/sample/extra-vars.yml recover-k8s-control-plane.yml --limit etcd,kube-master -e etcd_snapshot=/home/sample/k8s_backup/etcd-snapshot.db -e etcd_retries=10 --skip-tags=external-provisioner
+$ ansible-playbook -b -i inventory/sample/hosts.ini -e @inventory/sample/extra-vars.yml recover-k8s-control-plane.yml --limit etcd,kube_control_plane -e etcd_snapshot=/home/sample/k8s_backup/etcd-snapshot.db -e etcd_retries=10 --skip-tags=external-provisioner
 ```
 
 __장애 상황과 동일한 테스트 환경 구성하여 사전 검증 수행하는 것을 권장한다__
@@ -97,7 +97,7 @@ master, etcd 정상 동작 여부에 따라 2가지 방법으로 복구 작업�
   * master 복구: ```kubectl delete node``` 명령어 수행 가능
   * etcd 복구: ```etcdctl member remove``` 명령어 수행 가능
 
-* 정상 동작한다면 "broken\_kube-master", "broken\_etcd" 그룹 노드를 제거하고 cluster.yml 플레이북을 통해 신규 노드 재 구축
+* 정상 동작한다면 "broken\_kube_control_plane", "broken\_etcd" 그룹 노드를 제거하고 cluster.yml 플레이북을 통해 신규 노드 재 구축
 * 정상 동작하지 않는다면 etcd는 백업 데이터를 기반으로 single 클러스터를 구성하고 cluster.yml 플레이북을 통해 신규 노드 재 구축
   * kubespray 내부적으로 kubeadm 호출시 ```--ignore-preflight-errors=all``` 옵션을 사용하고 있기 때문에 인증서/키가 이미 존재하는 경우 해당 내용을 재사용
-  * "broken\_kube-master", "broken\_etcd" 내용이 실제로 사용되지는 않음
+  * "broken\_kube_control_plane", "broken\_etcd" 내용이 실제로 사용되지는 않음

--- a/inventory/sample/aio/hosts.ini
+++ b/inventory/sample/aio/hosts.ini
@@ -1,7 +1,7 @@
 taco-aio access_ip=127.0.0.1 ansible_connection=local
 
 # Kubernetes cluster
-[kube-master]
+[kube_control_plane]
 taco-aio
 
 [etcd]
@@ -11,10 +11,10 @@ taco-aio
 taco-aio
 
 [k8s-cluster:children]
-kube-master
+kube_control_plane
 kube-node
 
-[kube-master:vars]
+[kube_control_plane:vars]
 node_labels={"openstack-control-plane":"enabled", "openstack-compute-node":"enabled", "linuxbridge":"enabled", "taco-lma":"enabled", "fluent-logging":"enabled"}
 
 ## Ceph cluster: if you want Ceph only nodes, use the following group and lables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
-# from kubespray v2.15.1
-ansible==2.9.20
+# from kubespray v2.17.0
+ansible==3.4.0
+ansible-base==2.10.11
 cryptography==2.8
 jinja2==2.11.3
 netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
+ruamel.yaml.clib==0.2.2
+MarkupSafe==1.1.1
+
 
 # for taco
 docker

--- a/roles/k8s/clients/tasks/helm.yml
+++ b/roles/k8s/clients/tasks/helm.yml
@@ -6,7 +6,7 @@
     flat: yes
     validate_checksum: no
   become: no
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
 
 - name: copy helm to bin_dir
   copy:

--- a/roles/k8s/clients/tasks/kubectl.yml
+++ b/roles/k8s/clients/tasks/kubectl.yml
@@ -12,7 +12,7 @@
     dest: "{{ artifacts_dir }}/kubectl"
     flat: yes
     validate_checksum: no
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
 
 - name: copy kubectl to bin_dir
   copy:

--- a/roles/taco-apps/lma/pre-install/tasks/main.yml
+++ b/roles/taco-apps/lma/pre-install/tasks/main.yml
@@ -37,7 +37,7 @@
   register: stat_etcd_dir
   when:
   - create_etcd_secret
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Fail if etcd directory does not exist
@@ -46,7 +46,7 @@
   when:
   - create_etcd_secret
   - stat_etcd_dir.stat.exists == False
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Check if namespace exists
@@ -56,7 +56,7 @@
   ignore_errors: yes
   when:
   - create_etcd_secret
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Create namespace for lma
@@ -66,7 +66,7 @@
   when:
   - create_etcd_secret
   - is_namespace_existing.stdout == "0"
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Labeling namespace for lma
@@ -75,7 +75,7 @@
   register: label_namespace_result
   when:
   - create_etcd_secret
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Check if secret exists
@@ -85,21 +85,21 @@
   ignore_errors: yes
   when:
   - create_etcd_secret
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Create Secret for etcd monitoring
   command: >-
     {{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic etcd-client-cert
     --from-file=etcd-ca={{ etcd_cert_dir }}/ca.pem
-    --from-file=etcd-client={{ etcd_cert_dir }}/member-{{ groups['kube-master']|first }}.pem 
-    --from-file=etcd-client-key={{ etcd_cert_dir }}/member-{{ groups['kube-master']|first }}-key.pem 
+    --from-file=etcd-client={{ etcd_cert_dir }}/member-{{ groups['kube_control_plane']|first }}.pem 
+    --from-file=etcd-client-key={{ etcd_cert_dir }}/member-{{ groups['kube_control_plane']|first }}-key.pem 
     --namespace {{ lma_namespace }}
   register: secret_result
   when:
   - create_etcd_secret
   - is_secret_existing.stdout == "0"
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   run_once: true
 
 - name: Remove etcd log file


### PR DESCRIPTION
kubernetes v1.22를 지원하는 kubespray v2.17.0으로 변경하면서 inventory group과 requirement를 현행화하였습니다.

변경점)

- inventory에서 kube-master가 kube_control_plane으로 변경
- requirement의 필요 패키지 업데이트
- Jenkins에서 github checkout을 위해 token 업데이트